### PR TITLE
Changing some function signatures and a lot of small changes

### DIFF
--- a/worlds/apeescape/Items.py
+++ b/worlds/apeescape/Items.py
@@ -7,18 +7,8 @@ base_apeescape_item_id = 128000000
 
 
 class ApeEscapeItem(Item):
-    def __init__(self, name: str, classification: ItemClassification, code: Optional[int], player: int):
-        super().__init__(name, classification, code, player)
+    game: str = "Ape Escape"
 
-
-class ItemData:
-    def __init__(self, id: int, classification: ItemClassification):
-        self.classification = classification
-        self.id = None if id is None else id + base_apeescape_item_id
-        self.table_index = id
-
-
-nothing_item_id = base_apeescape_item_id
 
 # base IDs are the index in the static item data table, which is
 # not the same order as the items in RAM (but offset 0 is a 16-bit address of
@@ -40,7 +30,7 @@ item_table = {
     AEItem.Key.value: RAM.items["Key"],
     AEItem.Victory.value: RAM.items["Victory"],
 
-    #Junk
+    # Junk
     AEItem.Nothing.value: RAM.items["Nothing"],
     AEItem.Shirt.value: RAM.items["Shirt"],
     AEItem.Triangle.value: RAM.items["Triangle"],

--- a/worlds/apeescape/Locations.py
+++ b/worlds/apeescape/Locations.py
@@ -1,5 +1,4 @@
 from BaseClasses import Location
-import typing
 
 from worlds.apeescape.Strings import AELocation
 
@@ -8,10 +7,6 @@ base_location_id = 128000000
 
 class ApeEscapeLocation(Location):
     game: str = "Ape Escape"
-
-    def __init__(self, player: int, name: str, address: typing.Optional[int], parent):
-        super().__init__(player, name, address, parent)
-        self.event = not address
 
 
 location_table = {

--- a/worlds/apeescape/Options.py
+++ b/worlds/apeescape/Options.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from Options import Choice, Option, PerGameCommonOptions
-
-from typing import Dict
+from Options import Choice, PerGameCommonOptions
 
 
 class DebugOption(Choice):
@@ -102,7 +100,7 @@ class GadgetOption(Choice):
     default = option_club
 
 
-class  SuperFlyerOption(Choice):
+class SuperFlyerOption(Choice):
     """Choose if the Super Flyer trick should be put into logic
 
         true: super flyer is put into logic
@@ -115,7 +113,6 @@ class  SuperFlyerOption(Choice):
     option_true = 0x00
     option_false = 0x01
     default = option_false
-    
 
 
 @dataclass

--- a/worlds/apeescape/RAMAddress.py
+++ b/worlds/apeescape/RAMAddress.py
@@ -580,7 +580,7 @@ class RAM:
             197: 0x0DFE48,
             198: 0x0DFE49
         },
-        82: {  #outside climb
+        82: {  # outside climb
             199: 0x0DFE60,
             200: 0x0DFE61
         },
@@ -706,12 +706,12 @@ class RAM:
         91: 0xdfcb0
     }
 
-    #A bit is 1 if the gadget is unlocked. First bit is club, second is net, etc.
+    # A bit is 1 if the gadget is unlocked. First bit is club, second is net, etc.
     unlockedGadgetsAddress = 0x0F51C4
-    #the gadgets on triangle, square, circle, X on successive bytes
-    #club = 0, net = 1, radar = 2, sling = 3, hoop = 4, punch = 5, flyer = 6, car = 7, empty = 255
+    # the gadgets on triangle, square, circle, X on successive bytes
+    # club = 0, net = 1, radar = 2, sling = 3, hoop = 4, punch = 5, flyer = 6, car = 7, empty = 255
     equippedGadgetsAddress = 0x0F51A8
-    #which gadget is currently selected for use
+    # which gadget is currently selected for use
     selectedGadgetAddress = 0x0EC2D2
 
     trainingRoomProgressAddress = 0x0DFDCC

--- a/worlds/apeescape/Regions.py
+++ b/worlds/apeescape/Regions.py
@@ -1,764 +1,766 @@
-from BaseClasses import MultiWorld, Region, Entrance
-from .Options import ApeEscapeOptions
+from typing import TYPE_CHECKING
+
+from BaseClasses import Region, Entrance
 from .Locations import location_table, ApeEscapeLocation
 from .Strings import AEWorld, AERoom
 
+if TYPE_CHECKING:
+    from . import ApeEscapeWorld
 
-def create_regions(world: MultiWorld,options: ApeEscapeOptions, player: int):
+
+def create_regions(world: "ApeEscapeWorld"):
+    options = world.options
+    player = world.player
+    multiworld = world.multiworld
     # menu
-    menu = Region("Menu", player, world)
+    menu = Region("Menu", player, multiworld)
 
     # worlds
-    w1 = Region(AEWorld.W1.value, player, world)
-    w2 = Region(AEWorld.W2.value, player, world)
-    w3 = Region(AEWorld.W3.value, player, world)
-    w4 = Region(AEWorld.W4.value, player, world)
-    w5 = Region(AEWorld.W5.value, player, world)
-    w6 = Region(AEWorld.W6.value, player, world)
-    w7 = Region(AEWorld.W7.value, player, world)
-    w8 = Region(AEWorld.W8.value, player, world)
-    w9 = Region(AEWorld.W9.value, player, world)
+    w1 = Region(AEWorld.W1.value, player, multiworld)
+    w2 = Region(AEWorld.W2.value, player, multiworld)
+    w3 = Region(AEWorld.W3.value, player, multiworld)
+    w4 = Region(AEWorld.W4.value, player, multiworld)
+    w5 = Region(AEWorld.W5.value, player, multiworld)
+    w6 = Region(AEWorld.W6.value, player, multiworld)
+    w7 = Region(AEWorld.W7.value, player, multiworld)
+    w8 = Region(AEWorld.W8.value, player, multiworld)
+    w9 = Region(AEWorld.W9.value, player, multiworld)
 
     # 1-1
-    l11 = Region(AERoom.W1L1Main.value, player, world)
-    noonan = Region(AERoom.W1L1Noonan.value, player, world)
+    l11 = Region(AERoom.W1L1Main.value, player, multiworld)
+    noonan = Region(AERoom.W1L1Noonan.value, player, multiworld)
     noonan.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], noonan) for loc_name
                          in get_array([1])]
-    jorjy = Region(AERoom.W1L1Jorjy.value, player, world)
+    jorjy = Region(AERoom.W1L1Jorjy.value, player, multiworld)
     jorjy.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], jorjy) for loc_name
                         in get_array([2])]
-    nati = Region(AERoom.W1L1Nati.value, player, world)
+    nati = Region(AERoom.W1L1Nati.value, player, multiworld)
     nati.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], nati) for loc_name
                        in get_array([3])]
-    trayc = Region(AERoom.W1L1TrayC.value, player, world)
+    trayc = Region(AERoom.W1L1TrayC.value, player, multiworld)
     trayc.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], trayc) for loc_name
                         in get_array([4])]
 
     # 1-2
-    l12 = Region(AERoom.W1L2Main.value, player, world)
-    shay = Region(AERoom.W1L2Shay.value, player, world)
+    l12 = Region(AERoom.W1L2Main.value, player, multiworld)
+    shay = Region(AERoom.W1L2Shay.value, player, multiworld)
     shay.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], shay) for loc_name
                        in get_array([5])]
-    drmonk = Region(AERoom.W1L2DrMonk.value, player, world)
+    drmonk = Region(AERoom.W1L2DrMonk.value, player, multiworld)
     drmonk.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], drmonk) for loc_name
                          in get_array([6])]
-    grunt = Region(AERoom.W1L2Grunt.value, player, world)
+    grunt = Region(AERoom.W1L2Grunt.value, player, multiworld)
     grunt.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], grunt) for loc_name
                         in get_array([7])]
-    ahchoo = Region(AERoom.W1L2Ahchoo.value, player, world)
+    ahchoo = Region(AERoom.W1L2Ahchoo.value, player, multiworld)
     ahchoo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], ahchoo) for loc_name
                          in get_array([8])]
-    gornif = Region(AERoom.W1L2Gornif.value, player, world)
+    gornif = Region(AERoom.W1L2Gornif.value, player, multiworld)
     gornif.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], gornif) for loc_name
                          in get_array([9])]
-    tyrone = Region(AERoom.W1L2Tyrone.value, player, world)
+    tyrone = Region(AERoom.W1L2Tyrone.value, player, multiworld)
     tyrone.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], tyrone) for loc_name
                          in get_array([10])]
 
     # 1-3
-    l131 = Region(AERoom.W1L3Entry.value, player, world)
-    l132 = Region(AERoom.W1L3Volcano.value, player, world)
-    l133 = Region(AERoom.W1L3Triceratops.value, player, world)
-    scotty = Region(AERoom.W1L3Scotty.value, player, world)
+    l131 = Region(AERoom.W1L3Entry.value, player, multiworld)
+    l132 = Region(AERoom.W1L3Volcano.value, player, multiworld)
+    l133 = Region(AERoom.W1L3Triceratops.value, player, multiworld)
+    scotty = Region(AERoom.W1L3Scotty.value, player, multiworld)
     scotty.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], scotty) for loc_name
                          in get_array([11])]
-    coco = Region(AERoom.W1L3Coco.value, player, world)
+    coco = Region(AERoom.W1L3Coco.value, player, multiworld)
     coco.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coco) for loc_name
                        in get_array([12])]
-    jthomas = Region(AERoom.W1L3JThomas.value, player, world)
+    jthomas = Region(AERoom.W1L3JThomas.value, player, multiworld)
     jthomas.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], jthomas) for loc_name
                           in get_array([13])]
-    mattie = Region(AERoom.W1L3Mattie.value, player, world)
+    mattie = Region(AERoom.W1L3Mattie.value, player, multiworld)
     mattie.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mattie) for loc_name
                          in get_array([14])]
-    barney = Region(AERoom.W1L3Barney.value, player, world)
+    barney = Region(AERoom.W1L3Barney.value, player, multiworld)
     barney.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], barney) for loc_name
                          in get_array([15])]
-    rocky = Region(AERoom.W1L3Rocky.value, player, world)
+    rocky = Region(AERoom.W1L3Rocky.value, player, multiworld)
     rocky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], rocky) for loc_name
                         in get_array([16])]
-    moggan = Region(AERoom.W1L3Moggan.value, player, world)
+    moggan = Region(AERoom.W1L3Moggan.value, player, multiworld)
     moggan.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], moggan) for loc_name
                          in get_array([17])]
 
-
     # 2-1
-    l211 = Region(AERoom.W2L1Entry.value, player, world)
-    l212 = Region(AERoom.W2L1Mushroom.value, player, world)
-    l213 = Region(AERoom.W2L1Fish.value, player, world)
-    l214 = Region(AERoom.W2L1Tent.value, player, world)
-    l215 = Region(AERoom.W2L1Boulder.value, player, world)
-    marquez = Region(AERoom.W2L1Marquez.value, player, world)
+    l211 = Region(AERoom.W2L1Entry.value, player, multiworld)
+    l212 = Region(AERoom.W2L1Mushroom.value, player, multiworld)
+    l213 = Region(AERoom.W2L1Fish.value, player, multiworld)
+    l214 = Region(AERoom.W2L1Tent.value, player, multiworld)
+    l215 = Region(AERoom.W2L1Boulder.value, player, multiworld)
+    marquez = Region(AERoom.W2L1Marquez.value, player, multiworld)
     marquez.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], marquez) for loc_name
                           in get_array([18])]
-    livinston = Region(AERoom.W2L1Livinston.value, player, world)
+    livinston = Region(AERoom.W2L1Livinston.value, player, multiworld)
     livinston.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], livinston) for loc_name
                             in get_array([19])]
-    george = Region(AERoom.W2L1George.value, player, world)
+    george = Region(AERoom.W2L1George.value, player, multiworld)
     george.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], george) for loc_name
                          in get_array([20])]
-    gonzo = Region(AERoom.W2L1Gonzo.value, player, world)
+    gonzo = Region(AERoom.W2L1Gonzo.value, player, multiworld)
     gonzo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], gonzo) for loc_name
                         in get_array([29])]
-    zanzibar = Region(AERoom.W2L1Zanzibar.value, player, world)
+    zanzibar = Region(AERoom.W2L1Zanzibar.value, player, multiworld)
     zanzibar.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], zanzibar) for loc_name
                            in get_array([31])]
-    alphonse = Region(AERoom.W2L1Alphonse.value, player, world)
+    alphonse = Region(AERoom.W2L1Alphonse.value, player, multiworld)
     alphonse.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], alphonse) for loc_name
                            in get_array([30])]
-    maki = Region(AERoom.W2L1Maki.value, player, world)
+    maki = Region(AERoom.W2L1Maki.value, player, multiworld)
     maki.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], maki) for loc_name
                        in get_array([21])]
-    herb = Region(AERoom.W2L1Herb.value, player, world)
+    herb = Region(AERoom.W2L1Herb.value, player, multiworld)
     herb.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], herb) for loc_name
                        in get_array([22])]
-    dilweed = Region(AERoom.W2L1Dilweed.value, player, world)
+    dilweed = Region(AERoom.W2L1Dilweed.value, player, multiworld)
     dilweed.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], dilweed) for loc_name
                           in get_array([23])]
-    stoddy = Region(AERoom.W2L1Stoddy.value, player, world)
+    stoddy = Region(AERoom.W2L1Stoddy.value, player, multiworld)
     stoddy.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], stoddy) for loc_name
                          in get_array([25])]
-    mitong = Region(AERoom.W2L1Mitong.value, player, world)
+    mitong = Region(AERoom.W2L1Mitong.value, player, multiworld)
     mitong.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mitong) for loc_name
                          in get_array([24])]
-    nasus = Region(AERoom.W2L1Nasus.value, player, world)
+    nasus = Region(AERoom.W2L1Nasus.value, player, multiworld)
     nasus.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], nasus) for loc_name
                         in get_array([26])]
-    elehcim = Region(AERoom.W2L1Elehcim.value, player, world)
+    elehcim = Region(AERoom.W2L1Elehcim.value, player, multiworld)
     elehcim.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], elehcim) for loc_name
                           in get_array([28])]
-    selur = Region(AERoom.W2L1Selur.value, player, world)
+    selur = Region(AERoom.W2L1Selur.value, player, multiworld)
     selur.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], selur) for loc_name
                         in get_array([27])]
 
     # 2-2
-    l221 = Region(AERoom.W2L2Outside.value, player, world)
-    l222 = Region(AERoom.W2L2Fan.value, player, world)
-    l223 = Region(AERoom.W2L2Obelisk.value, player, world)
-    l224 = Region(AERoom.W2L2Water.value, player, world)
+    l221 = Region(AERoom.W2L2Outside.value, player, multiworld)
+    l222 = Region(AERoom.W2L2Fan.value, player, multiworld)
+    l223 = Region(AERoom.W2L2Obelisk.value, player, multiworld)
+    l224 = Region(AERoom.W2L2Water.value, player, multiworld)
 
-    mooshy = Region(AERoom.W2L2Mooshy.value, player, world)
+    mooshy = Region(AERoom.W2L2Mooshy.value, player, multiworld)
     mooshy.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mooshy) for loc_name in
                          get_array([32])]
-    kyle = Region(AERoom.W2L2Kyle.value, player, world)
+    kyle = Region(AERoom.W2L2Kyle.value, player, multiworld)
     kyle.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], kyle) for loc_name in
                        get_array([33])]
-    cratman = Region(AERoom.W2L2Cratman.value, player, world)
+    cratman = Region(AERoom.W2L2Cratman.value, player, multiworld)
     cratman.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], cratman) for loc_name in
                           get_array([34])]
-    nuzzy = Region(AERoom.W2L2Nuzzy.value, player, world)
+    nuzzy = Region(AERoom.W2L2Nuzzy.value, player, multiworld)
     nuzzy.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], nuzzy) for loc_name in
                         get_array([35])]
-    mav = Region(AERoom.W2L2Mav.value, player, world)
+    mav = Region(AERoom.W2L2Mav.value, player, multiworld)
     mav.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mav) for loc_name in
                       get_array([36])]
-    stan = Region(AERoom.W2L2Stan.value, player, world)
+    stan = Region(AERoom.W2L2Stan.value, player, multiworld)
     stan.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], stan) for loc_name in
                        get_array([37])]
-    bernt = Region(AERoom.W2L2Bernt.value, player, world)
+    bernt = Region(AERoom.W2L2Bernt.value, player, multiworld)
     bernt.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bernt) for loc_name in
                         get_array([38])]
-    runt = Region(AERoom.W2L2Runt.value, player, world)
+    runt = Region(AERoom.W2L2Runt.value, player, multiworld)
     runt.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], runt) for loc_name in
                        get_array([39])]
-    hoolah = Region(AERoom.W2L2Hoolah.value, player, world)
+    hoolah = Region(AERoom.W2L2Hoolah.value, player, multiworld)
     hoolah.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], hoolah) for loc_name in
                          get_array([40])]
-    papou = Region(AERoom.W2L2Papou.value, player, world)
+    papou = Region(AERoom.W2L2Papou.value, player, multiworld)
     papou.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], papou) for loc_name in
                         get_array([41])]
-    kenny = Region(AERoom.W2L2Kenny.value, player, world)
+    kenny = Region(AERoom.W2L2Kenny.value, player, multiworld)
     kenny.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], kenny) for loc_name in
                         get_array([42])]
-    trance = Region(AERoom.W2L2Trance.value, player, world)
+    trance = Region(AERoom.W2L2Trance.value, player, multiworld)
     trance.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], trance) for loc_name in
                          get_array([43])]
-    chino = Region(AERoom.W2L2Chino.value, player, world)
+    chino = Region(AERoom.W2L2Chino.value, player, multiworld)
     chino.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], chino) for loc_name in
                         get_array([44])]
 
     # 2-3
-    l231 = Region(AERoom.W2L3Outside.value, player, world)
-    l232 = Region(AERoom.W2L3Side.value, player, world)
-    l233 = Region(AERoom.W2L3Main.value, player, world)
-    l234 = Region(AERoom.W2L3Pillar.value, player, world)
+    l231 = Region(AERoom.W2L3Outside.value, player, multiworld)
+    l232 = Region(AERoom.W2L3Side.value, player, multiworld)
+    l233 = Region(AERoom.W2L3Main.value, player, multiworld)
+    l234 = Region(AERoom.W2L3Pillar.value, player, multiworld)
 
-    troopa = Region(AERoom.W2L3Troopa.value, player, world)
+    troopa = Region(AERoom.W2L3Troopa.value, player, multiworld)
     troopa.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], troopa) for loc_name in
                          get_array([45])]
-    spanky = Region(AERoom.W2L3Spanky.value, player, world)
+    spanky = Region(AERoom.W2L3Spanky.value, player, multiworld)
     spanky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], spanky) for loc_name in
                          get_array([46])]
-    stymie = Region(AERoom.W2L3Stymie.value, player, world)
+    stymie = Region(AERoom.W2L3Stymie.value, player, multiworld)
     stymie.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], stymie) for loc_name in
                          get_array([47])]
-    pally = Region(AERoom.W2L3Pally.value, player, world)
+    pally = Region(AERoom.W2L3Pally.value, player, multiworld)
     pally.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], pally) for loc_name in
                         get_array([48])]
-    freeto = Region(AERoom.W2L3Freeto.value, player, world)
+    freeto = Region(AERoom.W2L3Freeto.value, player, multiworld)
     freeto.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], freeto) for loc_name in
                          get_array([49])]
-    jesta = Region(AERoom.W2L3Jesta.value, player, world)
+    jesta = Region(AERoom.W2L3Jesta.value, player, multiworld)
     jesta.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], jesta) for loc_name in
                         get_array([50])]
-    bazzle = Region(AERoom.W2L3Bazzle.value, player, world)
+    bazzle = Region(AERoom.W2L3Bazzle.value, player, multiworld)
     bazzle.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bazzle) for loc_name in
                          get_array([51])]
-    crash = Region(AERoom.W2L3Crash.value, player, world)
+    crash = Region(AERoom.W2L3Crash.value, player, multiworld)
     crash.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], crash) for loc_name in
                         get_array([52])]
 
     # 4-1
-    l411 = Region(AERoom.W4L1FirstRoom.value, player, world)
-    l412 = Region(AERoom.W4L1SecondRoom.value, player, world)
-    coolblue = Region(AERoom.W4L1CoolBlue.value, player, world)
+    l411 = Region(AERoom.W4L1FirstRoom.value, player, multiworld)
+    l412 = Region(AERoom.W4L1SecondRoom.value, player, multiworld)
+    coolblue = Region(AERoom.W4L1CoolBlue.value, player, multiworld)
     coolblue.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coolblue) for loc_name in
                            get_array([53])]
-    sandy = Region(AERoom.W4L1Sandy.value, player, world)
+    sandy = Region(AERoom.W4L1Sandy.value, player, multiworld)
     sandy.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], sandy) for loc_name in
                         get_array([54])]
-    shelle = Region(AERoom.W4L1ShellE.value, player, world)
+    shelle = Region(AERoom.W4L1ShellE.value, player, multiworld)
     shelle.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], shelle) for loc_name in
                          get_array([55])]
-    gidget = Region(AERoom.W4L1Gidget.value, player, world)
+    gidget = Region(AERoom.W4L1Gidget.value, player, multiworld)
     gidget.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], gidget) for loc_name in
                          get_array([56])]
-    shaka = Region(AERoom.W4L1Shaka.value, player, world)
+    shaka = Region(AERoom.W4L1Shaka.value, player, multiworld)
     shaka.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], shaka) for loc_name in
                         get_array([57])]
-    maxmahalo = Region(AERoom.W4L1MaxMahalo.value, player, world)
+    maxmahalo = Region(AERoom.W4L1MaxMahalo.value, player, multiworld)
     maxmahalo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], maxmahalo) for loc_name in
                             get_array([58])]
-    moko = Region(AERoom.W4L1Moko.value, player, world)
+    moko = Region(AERoom.W4L1Moko.value, player, multiworld)
     moko.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], moko) for loc_name in
                        get_array([59])]
-    puka = Region(AERoom.W4L1Puka.value, player, world)
+    puka = Region(AERoom.W4L1Puka.value, player, multiworld)
     puka.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], puka) for loc_name in
                        get_array([60])]
 
     # 4-2
-    l421 = Region(AERoom.W4L2FirstRoom.value, player, world)
-    l422 = Region(AERoom.W4L2SecondRoom.value, player, world)
-    chip = Region(AERoom.W4L2Chip.value, player, world)
+    l421 = Region(AERoom.W4L2FirstRoom.value, player, multiworld)
+    l422 = Region(AERoom.W4L2SecondRoom.value, player, multiworld)
+    chip = Region(AERoom.W4L2Chip.value, player, multiworld)
     chip.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], chip) for loc_name in
                        get_array([61])]
-    oreo = Region(AERoom.W4L2Oreo.value, player, world)
+    oreo = Region(AERoom.W4L2Oreo.value, player, multiworld)
     oreo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], oreo) for loc_name in
                        get_array([62])]
-    puddles = Region(AERoom.W4L2Puddles.value, player, world)
+    puddles = Region(AERoom.W4L2Puddles.value, player, multiworld)
     puddles.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], puddles) for loc_name in
                           get_array([63])]
-    kalama = Region(AERoom.W4L2Kalama.value, player, world)
+    kalama = Region(AERoom.W4L2Kalama.value, player, multiworld)
     kalama.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], kalama) for loc_name in
                          get_array([64])]
-    iz = Region(AERoom.W4L2Iz.value, player, world)
+    iz = Region(AERoom.W4L2Iz.value, player, multiworld)
     iz.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], iz) for loc_name in
                      get_array([65])]
-    jux = Region(AERoom.W4L2Jux.value, player, world)
+    jux = Region(AERoom.W4L2Jux.value, player, multiworld)
     jux.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], jux) for loc_name in
                       get_array([66])]
-    bongbong = Region(AERoom.W4L2BongBong.value, player, world)
+    bongbong = Region(AERoom.W4L2BongBong.value, player, multiworld)
     bongbong.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bongbong) for loc_name in
                            get_array([67])]
-    pickles = Region(AERoom.W4L2Pickles.value, player, world)
+    pickles = Region(AERoom.W4L2Pickles.value, player, multiworld)
     pickles.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], pickles) for loc_name in
                           get_array([68])]
 
-
-
     # 4-3
-    l431 = Region(AERoom.W4L3Outside.value, player, world)
-    l432 = Region(AERoom.W4L3Stomach.value, player, world)
-    l433 = Region(AERoom.W4L3Slide.value, player, world)
-    l434 = Region(AERoom.W4L3Gallery.value, player, world)
-    l435 = Region(AERoom.W4L3Tentacle.value, player, world)
-    stuw = Region(AERoom.W4L3Stuw.value, player, world)
+    l431 = Region(AERoom.W4L3Outside.value, player, multiworld)
+    l432 = Region(AERoom.W4L3Stomach.value, player, multiworld)
+    l433 = Region(AERoom.W4L3Slide.value, player, multiworld)
+    l434 = Region(AERoom.W4L3Gallery.value, player, multiworld)
+    l435 = Region(AERoom.W4L3Tentacle.value, player, multiworld)
+    stuw = Region(AERoom.W4L3Stuw.value, player, multiworld)
     stuw.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], stuw) for loc_name in
                        get_array([69])]
-    tonton = Region(AERoom.W4L3TonTon.value, player, world)
+    tonton = Region(AERoom.W4L3TonTon.value, player, multiworld)
     tonton.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], tonton) for loc_name in
                          get_array([70])]
-    murky = Region(AERoom.W4L3Murky.value, player, world)
+    murky = Region(AERoom.W4L3Murky.value, player, multiworld)
     murky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], murky) for loc_name in
                         get_array([71])]
-    howeerd = Region(AERoom.W4L3Howeerd.value, player, world)
+    howeerd = Region(AERoom.W4L3Howeerd.value, player, multiworld)
     howeerd.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], howeerd) for loc_name in
                           get_array([72])]
-    robbin = Region(AERoom.W4L3Robbin.value, player, world)
+    robbin = Region(AERoom.W4L3Robbin.value, player, multiworld)
     robbin.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], robbin) for loc_name in
                          get_array([73])]
-    jakkee = Region(AERoom.W4L3Jakkee.value, player, world)
+    jakkee = Region(AERoom.W4L3Jakkee.value, player, multiworld)
     jakkee.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], jakkee) for loc_name in
                          get_array([74])]
-    frederic = Region(AERoom.W4L3Frederic.value, player, world)
+    frederic = Region(AERoom.W4L3Frederic.value, player, multiworld)
     frederic.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], frederic) for loc_name in
                            get_array([75])]
-    baba = Region(AERoom.W4L3Baba.value, player, world)
+    baba = Region(AERoom.W4L3Baba.value, player, multiworld)
     baba.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], baba) for loc_name in
                        get_array([76])]
-    mars = Region(AERoom.W4L3Mars.value, player, world)
+    mars = Region(AERoom.W4L3Mars.value, player, multiworld)
     mars.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mars) for loc_name in
                        get_array([77])]
-    horke = Region(AERoom.W4L3Horke.value, player, world)
+    horke = Region(AERoom.W4L3Horke.value, player, multiworld)
     horke.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], horke) for loc_name in
                         get_array([78])]
-    quirck = Region(AERoom.W4L3Quirck.value, player, world)
+    quirck = Region(AERoom.W4L3Quirck.value, player, multiworld)
     quirck.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], quirck) for loc_name in
                          get_array([79])]
 
-
-
     # 5-1
-    l51 = Region(AERoom.W5L1Main.value, player, world)
-    popcicle = Region(AERoom.W5L1Popcicle.value, player, world)
+    l51 = Region(AERoom.W5L1Main.value, player, multiworld)
+    popcicle = Region(AERoom.W5L1Popcicle.value, player, multiworld)
     popcicle.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], popcicle) for loc_name in
                            get_array([80])]
-    iced = Region(AERoom.W5L1Iced.value, player, world)
+    iced = Region(AERoom.W5L1Iced.value, player, multiworld)
     iced.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], iced) for loc_name in
                        get_array([81])]
-    denggoy = Region(AERoom.W5L1Denggoy.value, player, world)
+    denggoy = Region(AERoom.W5L1Denggoy.value, player, multiworld)
     denggoy.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], denggoy) for loc_name in
                           get_array([82])]
-    skeens = Region(AERoom.W5L1Skeens.value, player, world)
+    skeens = Region(AERoom.W5L1Skeens.value, player, multiworld)
     skeens.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], skeens) for loc_name in
                          get_array([83])]
-    rickets = Region(AERoom.W5L1Rickets.value, player, world)
+    rickets = Region(AERoom.W5L1Rickets.value, player, multiworld)
     rickets.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], rickets) for loc_name in
                           get_array([84])]
-    chilly = Region(AERoom.W5L1Chilly.value, player, world)
+    chilly = Region(AERoom.W5L1Chilly.value, player, multiworld)
     chilly.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], chilly) for loc_name in
                          get_array([85])]
 
     # 5-2
-    l521 = Region(AERoom.W5L2Entry.value, player, world)
-    l522 = Region(AERoom.W5L2Water.value, player, world)
-    l523 = Region(AERoom.W5L2Caverns.value, player, world)
-    storm = Region(AERoom.W5L2Storm.value, player, world)
+    l521 = Region(AERoom.W5L2Entry.value, player, multiworld)
+    l522 = Region(AERoom.W5L2Water.value, player, multiworld)
+    l523 = Region(AERoom.W5L2Caverns.value, player, multiworld)
+    storm = Region(AERoom.W5L2Storm.value, player, multiworld)
     storm.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], storm) for loc_name in
                         get_array([86])]
-    qube = Region(AERoom.W5L2Qube.value, player, world)
+    qube = Region(AERoom.W5L2Qube.value, player, multiworld)
     qube.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], qube) for loc_name in
                        get_array([87])]
-    gash = Region(AERoom.W5L2Gash.value, player, world)
+    gash = Region(AERoom.W5L2Gash.value, player, multiworld)
     gash.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], gash) for loc_name in
                        get_array([88])]
-    kundra = Region(AERoom.W5L2Kundra.value, player, world)
+    kundra = Region(AERoom.W5L2Kundra.value, player, multiworld)
     kundra.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], kundra) for loc_name in
                          get_array([89])]
-    shadow = Region(AERoom.W5L2Shadow.value, player, world)
+    shadow = Region(AERoom.W5L2Shadow.value, player, multiworld)
     shadow.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], shadow) for loc_name in
                          get_array([90])]
-    ranix = Region(AERoom.W5L2Ranix.value, player, world)
+    ranix = Region(AERoom.W5L2Ranix.value, player, multiworld)
     ranix.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], ranix) for loc_name in
                         get_array([91])]
-    sticky = Region(AERoom.W5L2Sticky.value, player, world)
+    sticky = Region(AERoom.W5L2Sticky.value, player, multiworld)
     sticky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], sticky) for loc_name in
                          get_array([92])]
-    sharpe = Region(AERoom.W5L2Sharpe.value, player, world)
+    sharpe = Region(AERoom.W5L2Sharpe.value, player, multiworld)
     sharpe.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], sharpe) for loc_name in
                          get_array([93])]
-    droog = Region(AERoom.W5L2Droog.value, player, world)
+    droog = Region(AERoom.W5L2Droog.value, player, multiworld)
     droog.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], droog) for loc_name in
                         get_array([94])]
 
     # 5-3
-    l531 = Region(AERoom.W5L3Outside.value, player, world)
-    l532 = Region(AERoom.W5L3Spring.value, player, world)
-    l533 = Region(AERoom.W5L3Cave.value, player, world)
-    punky = Region(AERoom.W5L3Punky.value, player, world)
+    l531 = Region(AERoom.W5L3Outside.value, player, multiworld)
+    l532 = Region(AERoom.W5L3Spring.value, player, multiworld)
+    l533 = Region(AERoom.W5L3Cave.value, player, multiworld)
+    punky = Region(AERoom.W5L3Punky.value, player, multiworld)
     punky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], punky) for loc_name in
                         get_array([95])]
-    ameego = Region(AERoom.W5L3Ameego.value, player, world)
+    ameego = Region(AERoom.W5L3Ameego.value, player, multiworld)
     ameego.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], ameego) for loc_name in
                          get_array([96])]
-    roti = Region(AERoom.W5L3Roti.value, player, world)
+    roti = Region(AERoom.W5L3Roti.value, player, multiworld)
     roti.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], roti) for loc_name in
                        get_array([97])]
-    dissa = Region(AERoom.W5L3Dissa.value, player, world)
+    dissa = Region(AERoom.W5L3Dissa.value, player, multiworld)
     dissa.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], dissa) for loc_name in
                         get_array([98])]
-    yoky = Region(AERoom.W5L3Yoky.value, player, world)
+    yoky = Region(AERoom.W5L3Yoky.value, player, multiworld)
     yoky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], yoky) for loc_name in
                        get_array([99])]
-    jory = Region(AERoom.W5L3Jory.value, player, world)
+    jory = Region(AERoom.W5L3Jory.value, player, multiworld)
     jory.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], jory) for loc_name in
                        get_array([100])]
-    crank = Region(AERoom.W5L3Crank.value, player, world)
+    crank = Region(AERoom.W5L3Crank.value, player, multiworld)
     crank.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], crank) for loc_name in
                         get_array([101])]
-    claxter = Region(AERoom.W5L3Claxter.value, player, world)
+    claxter = Region(AERoom.W5L3Claxter.value, player, multiworld)
     claxter.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], claxter) for loc_name in
                           get_array([102])]
-    looza = Region(AERoom.W5L3Looza.value, player, world)
+    looza = Region(AERoom.W5L3Looza.value, player, multiworld)
     looza.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], looza) for loc_name in
                         get_array([103])]
 
     # 7-1
-    l711 = Region(AERoom.W7L1Outside.value, player, world)
-    l712 = Region(AERoom.W7L1Temple.value, player, world)
-    l713 = Region(AERoom.W7L1Well.value, player, world)
-    taku = Region(AERoom.W7L1Taku.value, player, world)
+    l711 = Region(AERoom.W7L1Outside.value, player, multiworld)
+    l712 = Region(AERoom.W7L1Temple.value, player, multiworld)
+    l713 = Region(AERoom.W7L1Well.value, player, multiworld)
+    taku = Region(AERoom.W7L1Taku.value, player, multiworld)
     taku.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], taku) for loc_name in
                        get_array([104])]
-    rocka = Region(AERoom.W7L1Rocka.value, player, world)
+    rocka = Region(AERoom.W7L1Rocka.value, player, multiworld)
     rocka.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], rocka) for loc_name in
                         get_array([105])]
-    maralea = Region(AERoom.W7L1Maralea.value, player, world)
+    maralea = Region(AERoom.W7L1Maralea.value, player, multiworld)
     maralea.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], maralea) for loc_name in
                           get_array([106])]
-    wog = Region(AERoom.W7L1Wog.value, player, world)
+    wog = Region(AERoom.W7L1Wog.value, player, multiworld)
     wog.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], wog) for loc_name in
                       get_array([107])]
-    long = Region(AERoom.W7L1Long.value, player, world)
+    long = Region(AERoom.W7L1Long.value, player, multiworld)
     long.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], long) for loc_name in
                        get_array([108])]
-    mayi = Region(AERoom.W7L1Mayi.value, player, world)
+    mayi = Region(AERoom.W7L1Mayi.value, player, multiworld)
     mayi.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mayi) for loc_name in
                        get_array([109])]
-    owyang = Region(AERoom.W7L1Owyang.value, player, world)
+    owyang = Region(AERoom.W7L1Owyang.value, player, multiworld)
     owyang.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], owyang) for loc_name in
                          get_array([110])]
-    queltin = Region(AERoom.W7L1QuelTin.value, player, world)
+    queltin = Region(AERoom.W7L1QuelTin.value, player, multiworld)
     queltin.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], queltin) for loc_name in
                           get_array([111])]
-    phaldo = Region(AERoom.W7L1Phaldo.value, player, world)
+    phaldo = Region(AERoom.W7L1Phaldo.value, player, multiworld)
     phaldo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], phaldo) for loc_name in
                          get_array([112])]
-    voti = Region(AERoom.W7L1Voti.value, player, world)
+    voti = Region(AERoom.W7L1Voti.value, player, multiworld)
     voti.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], voti) for loc_name in
                        get_array([113])]
-    elly = Region(AERoom.W7L1Elly.value, player, world)
+    elly = Region(AERoom.W7L1Elly.value, player, multiworld)
     elly.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], elly) for loc_name in
                        get_array([114])]
-    chunky = Region(AERoom.W7L1Chunky.value, player, world)
+    chunky = Region(AERoom.W7L1Chunky.value, player, multiworld)
     chunky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], chunky) for loc_name in
                          get_array([115])]
 
     # 7-2
-    l721 = Region(AERoom.W7L2First.value, player, world)
-    l722 = Region(AERoom.W7L2Gong.value, player, world)
-    l723 = Region(AERoom.W7L2Middle.value, player, world)
-    l724 = Region(AERoom.W7L2Course.value, player, world)
-    l725 = Region(AERoom.W7L2Barrel.value, player, world)
-    minky = Region(AERoom.W7L2Minky.value, player, world)
+    l721 = Region(AERoom.W7L2First.value, player, multiworld)
+    l722 = Region(AERoom.W7L2Gong.value, player, multiworld)
+    l723 = Region(AERoom.W7L2Middle.value, player, multiworld)
+    l724 = Region(AERoom.W7L2Course.value, player, multiworld)
+    l725 = Region(AERoom.W7L2Barrel.value, player, multiworld)
+    minky = Region(AERoom.W7L2Minky.value, player, multiworld)
     minky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], minky) for loc_name in
                         get_array([116])]
-    zobbro = Region(AERoom.W7L2Zobbro.value, player, world)
+    zobbro = Region(AERoom.W7L2Zobbro.value, player, multiworld)
     zobbro.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], zobbro) for loc_name in
                          get_array([117])]
-    xeeto = Region(AERoom.W7L2Xeeto.value, player, world)
+    xeeto = Region(AERoom.W7L2Xeeto.value, player, multiworld)
     xeeto.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], xeeto) for loc_name in
                         get_array([118])]
-    moops = Region(AERoom.W7L2Moops.value, player, world)
+    moops = Region(AERoom.W7L2Moops.value, player, multiworld)
     moops.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], moops) for loc_name in
                         get_array([119])]
-    zanabi = Region(AERoom.W7L2Zanabi.value, player, world)
+    zanabi = Region(AERoom.W7L2Zanabi.value, player, multiworld)
     zanabi.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], zanabi) for loc_name in
                          get_array([120])]
-    buddah = Region(AERoom.W7L2Buddha.value, player, world)
+    buddah = Region(AERoom.W7L2Buddha.value, player, multiworld)
     buddah.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], buddah) for loc_name in
                          get_array([121])]
-    fooey = Region(AERoom.W7L2Fooey.value, player, world)
+    fooey = Region(AERoom.W7L2Fooey.value, player, multiworld)
     fooey.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], fooey) for loc_name in
                         get_array([122])]
-    doxs = Region(AERoom.W7L2Doxs.value, player, world)
+    doxs = Region(AERoom.W7L2Doxs.value, player, multiworld)
     doxs.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], doxs) for loc_name in
                        get_array([123])]
-    kong = Region(AERoom.W7L2Kong.value, player, world)
+    kong = Region(AERoom.W7L2Kong.value, player, multiworld)
     kong.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], kong) for loc_name in
                        get_array([124])]
-    phool = Region(AERoom.W7L2Phool.value, player, world)
+    phool = Region(AERoom.W7L2Phool.value, player, multiworld)
     phool.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], phool) for loc_name in
                         get_array([125])]
 
     # 7-3
-    l731 = Region(AERoom.W7L3Outside.value, player, world)
-    l732 = Region(AERoom.W7L3Castle.value, player, world)
-    l733 = Region(AERoom.W7L3Basement.value, player, world)
-    l734 = Region(AERoom.W7L3Button.value, player, world)
-    l735 = Region(AERoom.W7L3Elevator.value, player, world)
-    l736 = Region(AERoom.W7L3Bell.value, player, world)
-    l737 = Region(AERoom.W7L3Boss.value, player, world)
+    l731 = Region(AERoom.W7L3Outside.value, player, multiworld)
+    l732 = Region(AERoom.W7L3Castle.value, player, multiworld)
+    l733 = Region(AERoom.W7L3Basement.value, player, multiworld)
+    l734 = Region(AERoom.W7L3Button.value, player, multiworld)
+    l735 = Region(AERoom.W7L3Elevator.value, player, multiworld)
+    l736 = Region(AERoom.W7L3Bell.value, player, multiworld)
+    l737 = Region(AERoom.W7L3Boss.value, player, multiworld)
 
-    naners = Region(AERoom.W7L3Naners.value, player, world)
+    naners = Region(AERoom.W7L3Naners.value, player, multiworld)
     naners.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], naners) for loc_name in
                          get_array([126])]
-    robart = Region(AERoom.W7L3Robart.value, player, world)
+    robart = Region(AERoom.W7L3Robart.value, player, multiworld)
     robart.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], robart) for loc_name in
                          get_array([127])]
-    neeners = Region(AERoom.W7L3Neeners.value, player, world)
+    neeners = Region(AERoom.W7L3Neeners.value, player, multiworld)
     neeners.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], neeners) for loc_name in
                           get_array([128])]
-    gustav = Region(AERoom.W7L3Gustav.value, player, world)
+    gustav = Region(AERoom.W7L3Gustav.value, player, multiworld)
     gustav.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], gustav) for loc_name in
                          get_array([129])]
-    wilhelm = Region(AERoom.W7L3Wilhelm.value, player, world)
+    wilhelm = Region(AERoom.W7L3Wilhelm.value, player, multiworld)
     wilhelm.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], wilhelm) for loc_name in
                           get_array([130])]
-    emmanuel = Region(AERoom.W7L3Emmanuel.value, player, world)
+    emmanuel = Region(AERoom.W7L3Emmanuel.value, player, multiworld)
     emmanuel.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], emmanuel) for loc_name in
                            get_array([131])]
-    sircutty = Region(AERoom.W7L3SirCutty.value, player, world)
+    sircutty = Region(AERoom.W7L3SirCutty.value, player, multiworld)
     sircutty.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], sircutty) for loc_name in
                            get_array([132])]
-    calligan = Region(AERoom.W7L3Calligan.value, player, world)
+    calligan = Region(AERoom.W7L3Calligan.value, player, multiworld)
     calligan.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], calligan) for loc_name in
                            get_array([133])]
-    castalist = Region(AERoom.W7L3Castalist.value, player, world)
+    castalist = Region(AERoom.W7L3Castalist.value, player, multiworld)
     castalist.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], castalist) for loc_name in
                             get_array([134])]
-    deveneom = Region(AERoom.W7L3Deveneom.value, player, world)
+    deveneom = Region(AERoom.W7L3Deveneom.value, player, multiworld)
     deveneom.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], deveneom) for loc_name in
                            get_array([135])]
-    igor = Region(AERoom.W7L3Igor.value, player, world)
+    igor = Region(AERoom.W7L3Igor.value, player, multiworld)
     igor.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], igor) for loc_name in
                        get_array([136])]
-    charles = Region(AERoom.W7L3Charles.value, player, world)
+    charles = Region(AERoom.W7L3Charles.value, player, multiworld)
     charles.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], charles) for loc_name in
                           get_array([137])]
-    astur = Region(AERoom.W7L3Astur.value, player, world)
+    astur = Region(AERoom.W7L3Astur.value, player, multiworld)
     astur.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], astur) for loc_name in
                         get_array([138])]
-    kilserack = Region(AERoom.W7L3Kilserack.value, player, world)
+    kilserack = Region(AERoom.W7L3Kilserack.value, player, multiworld)
     kilserack.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], kilserack) for loc_name in
                             get_array([139])]
-    ringo = Region(AERoom.W7L3Ringo.value, player, world)
+    ringo = Region(AERoom.W7L3Ringo.value, player, multiworld)
     ringo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], ringo) for loc_name in
                         get_array([140])]
-    densil = Region(AERoom.W7L3Densil.value, player, world)
+    densil = Region(AERoom.W7L3Densil.value, player, multiworld)
     densil.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], densil) for loc_name in
                          get_array([141])]
-    figero = Region(AERoom.W7L3Figero.value, player, world)
+    figero = Region(AERoom.W7L3Figero.value, player, multiworld)
     figero.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], figero) for loc_name in
                          get_array([142])]
-    fej = Region(AERoom.W7L3Fej.value, player, world)
+    fej = Region(AERoom.W7L3Fej.value, player, multiworld)
     fej.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], fej) for loc_name in
                       get_array([143])]
-    joey = Region(AERoom.W7L3Joey.value, player, world)
+    joey = Region(AERoom.W7L3Joey.value, player, multiworld)
     joey.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], joey) for loc_name in
                        get_array([144])]
-    donqui = Region(AERoom.W7L3Donqui.value, player, world)
+    donqui = Region(AERoom.W7L3Donqui.value, player, multiworld)
     donqui.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], donqui) for loc_name in
                          get_array([145])]
 
     # 8-1
-    l811 = Region(AERoom.W8L1Outside.value, player, world)
-    l812 = Region(AERoom.W8L1Sewers.value, player, world)
-    l813 = Region(AERoom.W8L1Barrel.value, player, world)
+    l811 = Region(AERoom.W8L1Outside.value, player, multiworld)
+    l812 = Region(AERoom.W8L1Sewers.value, player, multiworld)
+    l813 = Region(AERoom.W8L1Barrel.value, player, multiworld)
 
-    kaine = Region(AERoom.W8L1Kaine.value, player, world)
+    kaine = Region(AERoom.W8L1Kaine.value, player, multiworld)
     kaine.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], kaine) for loc_name in
                         get_array([146])]
-    jaxx = Region(AERoom.W8L1Jaxx.value, player, world)
+    jaxx = Region(AERoom.W8L1Jaxx.value, player, multiworld)
     jaxx.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], jaxx) for loc_name in
                        get_array([147])]
-    gehry = Region(AERoom.W8L1Gehry.value, player, world)
+    gehry = Region(AERoom.W8L1Gehry.value, player, multiworld)
     gehry.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], gehry) for loc_name in
                         get_array([148])]
-    alcatraz = Region(AERoom.W8L1Alcatraz.value, player, world)
+    alcatraz = Region(AERoom.W8L1Alcatraz.value, player, multiworld)
     alcatraz.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], alcatraz) for loc_name in
                            get_array([149])]
-    tino = Region(AERoom.W8L1Tino.value, player, world)
+    tino = Region(AERoom.W8L1Tino.value, player, multiworld)
     tino.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], tino) for loc_name in
                        get_array([150])]
-    qbee = Region(AERoom.W8L1QBee.value, player, world)
+    qbee = Region(AERoom.W8L1QBee.value, player, multiworld)
     qbee.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], qbee) for loc_name in
                        get_array([151])]
-    mcmanic = Region(AERoom.W8L1McManic.value, player, world)
+    mcmanic = Region(AERoom.W8L1McManic.value, player, multiworld)
     mcmanic.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mcmanic) for loc_name in
                           get_array([152])]
-    dywan = Region(AERoom.W8L1Dywan.value, player, world)
+    dywan = Region(AERoom.W8L1Dywan.value, player, multiworld)
     dywan.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], dywan) for loc_name in
                         get_array([153])]
-    ckhutch = Region(AERoom.W8L1CKHutch.value, player, world)
+    ckhutch = Region(AERoom.W8L1CKHutch.value, player, multiworld)
     ckhutch.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], ckhutch) for loc_name in
                           get_array([154])]
-    winky = Region(AERoom.W8L1Winky.value, player, world)
+    winky = Region(AERoom.W8L1Winky.value, player, multiworld)
     winky.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], winky) for loc_name in
                         get_array([155])]
-    bluv = Region(AERoom.W8L1BLuv.value, player, world)
+    bluv = Region(AERoom.W8L1BLuv.value, player, multiworld)
     bluv.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bluv) for loc_name in
                        get_array([156])]
-    camper = Region(AERoom.W8L1Camper.value, player, world)
+    camper = Region(AERoom.W8L1Camper.value, player, multiworld)
     camper.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], camper) for loc_name in
                          get_array([157])]
-    huener = Region(AERoom.W8L1Huener.value, player, world)
+    huener = Region(AERoom.W8L1Huener.value, player, multiworld)
     huener.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], huener) for loc_name in
                          get_array([158])]
 
     # 8-2
-    l821 = Region(AERoom.W8L2Outside.value, player, world)
-    l822 = Region(AERoom.W8L2Factory.value, player, world)
-    l823 = Region(AERoom.W8L2RC.value, player, world)
-    l824 = Region(AERoom.W8L2Lava.value, player, world)
-    l825 = Region(AERoom.W8L2Conveyor.value, player, world)
-    l826 = Region(AERoom.W8L2Mech.value, player, world)
+    l821 = Region(AERoom.W8L2Outside.value, player, multiworld)
+    l822 = Region(AERoom.W8L2Factory.value, player, multiworld)
+    l823 = Region(AERoom.W8L2RC.value, player, multiworld)
+    l824 = Region(AERoom.W8L2Lava.value, player, multiworld)
+    l825 = Region(AERoom.W8L2Conveyor.value, player, multiworld)
+    l826 = Region(AERoom.W8L2Mech.value, player, multiworld)
 
-    bigshow = Region(AERoom.W8L2BigShow.value, player, world)
+    bigshow = Region(AERoom.W8L2BigShow.value, player, multiworld)
     bigshow.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bigshow) for loc_name in
                           get_array([159])]
-    dreos = Region(AERoom.W8L2Dreos.value, player, world)
+    dreos = Region(AERoom.W8L2Dreos.value, player, multiworld)
     dreos.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], dreos) for loc_name in
                         get_array([160])]
-    reznor = Region(AERoom.W8L2Reznor.value, player, world)
+    reznor = Region(AERoom.W8L2Reznor.value, player, multiworld)
     reznor.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], reznor) for loc_name in
                          get_array([161])]
-    urkel = Region(AERoom.W8L2Urkel.value, player, world)
+    urkel = Region(AERoom.W8L2Urkel.value, player, multiworld)
     urkel.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], urkel) for loc_name in
                         get_array([162])]
-    vanillas = Region(AERoom.W8L2VanillaS.value, player, world)
+    vanillas = Region(AERoom.W8L2VanillaS.value, player, multiworld)
     vanillas.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], vanillas) for loc_name in
                            get_array([163])]
-    radd = Region(AERoom.W8L2Radd.value, player, world)
+    radd = Region(AERoom.W8L2Radd.value, player, multiworld)
     radd.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], radd) for loc_name in
                        get_array([164])]
-    shimbo = Region(AERoom.W8L2Shimbo.value, player, world)
+    shimbo = Region(AERoom.W8L2Shimbo.value, player, multiworld)
     shimbo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], shimbo) for loc_name in
                          get_array([165])]
-    hurt = Region(AERoom.W8L2Hurt.value, player, world)
+    hurt = Region(AERoom.W8L2Hurt.value, player, multiworld)
     hurt.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], hurt) for loc_name in
                        get_array([166])]
-    strung = Region(AERoom.W8L2String.value, player, world)
+    strung = Region(AERoom.W8L2String.value, player, multiworld)
     strung.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], strung) for loc_name in
                          get_array([167])]
-    khamo = Region(AERoom.W8L2Khamo.value, player, world)
+    khamo = Region(AERoom.W8L2Khamo.value, player, multiworld)
     khamo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], khamo) for loc_name in
                         get_array([168])]
 
     # 8-3
-    l831 = Region(AERoom.W8L3Outside.value, player, world)
-    l832 = Region(AERoom.W8L3Water.value, player, world)
-    l833 = Region(AERoom.W8L3Lobby.value, player, world)
-    l834 = Region(AERoom.W8L3Tank.value, player, world)
-    l835 = Region(AERoom.W8L3Fan.value, player, world)
-    l836 = Region(AERoom.W8L3Boss.value, player, world)
+    l831 = Region(AERoom.W8L3Outside.value, player, multiworld)
+    l832 = Region(AERoom.W8L3Water.value, player, multiworld)
+    l833 = Region(AERoom.W8L3Lobby.value, player, multiworld)
+    l834 = Region(AERoom.W8L3Tank.value, player, multiworld)
+    l835 = Region(AERoom.W8L3Fan.value, player, multiworld)
+    l836 = Region(AERoom.W8L3Boss.value, player, multiworld)
 
-    fredo = Region(AERoom.W8L3Fredo.value, player, world)
+    fredo = Region(AERoom.W8L3Fredo.value, player, multiworld)
     fredo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], fredo) for loc_name in
                         get_array([169])]
-    charlee = Region(AERoom.W8L3Charlee.value, player, world)
+    charlee = Region(AERoom.W8L3Charlee.value, player, multiworld)
     charlee.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], charlee) for loc_name in
                           get_array([170])]
-    mach3 = Region(AERoom.W8L3Mach3.value, player, world)
+    mach3 = Region(AERoom.W8L3Mach3.value, player, multiworld)
     mach3.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], mach3) for loc_name in
                         get_array([171])]
-    tortuss = Region(AERoom.W8L3Tortuss.value, player, world)
+    tortuss = Region(AERoom.W8L3Tortuss.value, player, multiworld)
     tortuss.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], tortuss) for loc_name in
                           get_array([172])]
-    manic = Region(AERoom.W8L3Manic.value, player, world)
+    manic = Region(AERoom.W8L3Manic.value, player, multiworld)
     manic.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], manic) for loc_name in
                         get_array([173])]
-    ruptdis = Region(AERoom.W8L3Ruptdis.value, player, world)
+    ruptdis = Region(AERoom.W8L3Ruptdis.value, player, multiworld)
     ruptdis.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], ruptdis) for loc_name in
                           get_array([174])]
-    eighty7 = Region(AERoom.W8L3Eighty7.value, player, world)
+    eighty7 = Region(AERoom.W8L3Eighty7.value, player, multiworld)
     eighty7.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], eighty7) for loc_name in
                           get_array([175])]
-    danio = Region(AERoom.W8L3Danio.value, player, world)
+    danio = Region(AERoom.W8L3Danio.value, player, multiworld)
     danio.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], danio) for loc_name in
                         get_array([176])]
-    roosta = Region(AERoom.W8L3Roosta.value, player, world)
+    roosta = Region(AERoom.W8L3Roosta.value, player, multiworld)
     roosta.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], roosta) for loc_name in
                          get_array([177])]
-    tellis = Region(AERoom.W8L3Tellis.value, player, world)
+    tellis = Region(AERoom.W8L3Tellis.value, player, multiworld)
     tellis.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], tellis) for loc_name in
                          get_array([178])]
-    whack = Region(AERoom.W8L3Whack.value, player, world)
+    whack = Region(AERoom.W8L3Whack.value, player, multiworld)
     whack.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], whack) for loc_name in
                         get_array([179])]
-    frostee = Region(AERoom.W8L3Frostee.value, player, world)
+    frostee = Region(AERoom.W8L3Frostee.value, player, multiworld)
     frostee.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], frostee) for loc_name in
                           get_array([180])]
 
     # 9-1
-    l911 = Region(AERoom.W9L1Entry.value, player, world)
-    l912 = Region(AERoom.W9L1Haunted.value, player, world)
-    l913 = Region(AERoom.W9L1Coffin.value, player, world)
-    l914 = Region(AERoom.W9L1Natalie.value, player, world)
-    l915 = Region(AERoom.W9L1Professor.value, player, world)
-    l916 = Region(AERoom.W9L1Jake.value, player, world)
-    l917 = Region(AERoom.W9L1Western.value, player, world)
-    l918 = Region(AERoom.W9L1Crater.value, player, world)
-    l919 = Region(AERoom.W9L1Outside.value, player, world)
-    l9110 = Region(AERoom.W9L1Castle.value, player, world)
-    l9111 = Region(AERoom.W9L1Climb1.value, player, world)
-    l9112 = Region(AERoom.W9L1Climb2.value, player, world)
-    l9113 = Region(AERoom.W9L1Head.value, player, world)
-    l9114 = Region(AERoom.W9L1Side.value, player, world)
-    l9115 = Region(AERoom.W9L1Boss.value, player, world)
+    l911 = Region(AERoom.W9L1Entry.value, player, multiworld)
+    l912 = Region(AERoom.W9L1Haunted.value, player, multiworld)
+    l913 = Region(AERoom.W9L1Coffin.value, player, multiworld)
+    l914 = Region(AERoom.W9L1Natalie.value, player, multiworld)
+    l915 = Region(AERoom.W9L1Professor.value, player, multiworld)
+    l916 = Region(AERoom.W9L1Jake.value, player, multiworld)
+    l917 = Region(AERoom.W9L1Western.value, player, multiworld)
+    l918 = Region(AERoom.W9L1Crater.value, player, multiworld)
+    l919 = Region(AERoom.W9L1Outside.value, player, multiworld)
+    l9110 = Region(AERoom.W9L1Castle.value, player, multiworld)
+    l9111 = Region(AERoom.W9L1Climb1.value, player, multiworld)
+    l9112 = Region(AERoom.W9L1Climb2.value, player, multiworld)
+    l9113 = Region(AERoom.W9L1Head.value, player, multiworld)
+    l9114 = Region(AERoom.W9L1Side.value, player, multiworld)
+    l9115 = Region(AERoom.W9L1Boss.value, player, multiworld)
     l9115.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], l9115) for loc_name in
                         get_array([205])]
 
-    goopo = Region(AERoom.W9L1Goopo.value, player, world)
+    goopo = Region(AERoom.W9L1Goopo.value, player, multiworld)
     goopo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], goopo) for loc_name in
                         get_array([181])]
-    porto = Region(AERoom.W9L1Porto.value, player, world)
+    porto = Region(AERoom.W9L1Porto.value, player, multiworld)
     porto.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], porto) for loc_name in
                         get_array([182])]
-    slam = Region(AERoom.W9L1Slam.value, player, world)
+    slam = Region(AERoom.W9L1Slam.value, player, multiworld)
     slam.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], slam) for loc_name in
                        get_array([183])]
-    junk = Region(AERoom.W9L1Junk.value, player, world)
+    junk = Region(AERoom.W9L1Junk.value, player, multiworld)
     junk.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], junk) for loc_name in
                        get_array([184])]
-    crib = Region(AERoom.W9L1Crib.value, player, world)
+    crib = Region(AERoom.W9L1Crib.value, player, multiworld)
     crib.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], crib) for loc_name in
                        get_array([185])]
-    nak = Region(AERoom.W9L1Nak.value, player, world)
+    nak = Region(AERoom.W9L1Nak.value, player, multiworld)
     nak.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], nak) for loc_name in
                       get_array([186])]
-    cloy = Region(AERoom.W9L1Cloy.value, player, world)
+    cloy = Region(AERoom.W9L1Cloy.value, player, multiworld)
     cloy.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], cloy) for loc_name in
                        get_array([187])]
-    shaw = Region(AERoom.W9L1Shaw.value, player, world)
+    shaw = Region(AERoom.W9L1Shaw.value, player, multiworld)
     shaw.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], shaw) for loc_name in
                        get_array([188])]
-    flea = Region(AERoom.W9L1Flea.value, player, world)
+    flea = Region(AERoom.W9L1Flea.value, player, multiworld)
     flea.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], flea) for loc_name in
                        get_array([189])]
-    schafette = Region(AERoom.W9L1Schafette.value, player, world)
+    schafette = Region(AERoom.W9L1Schafette.value, player, multiworld)
     schafette.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], schafette) for loc_name in
                             get_array([190])]
-    donovan = Region(AERoom.W9L1Donovan.value, player, world)
+    donovan = Region(AERoom.W9L1Donovan.value, player, multiworld)
     donovan.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], donovan) for loc_name in
                           get_array([191])]
-    laura = Region(AERoom.W9L1Laura.value, player, world)
+    laura = Region(AERoom.W9L1Laura.value, player, multiworld)
     laura.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], laura) for loc_name in
                         get_array([192])]
-    uribe = Region(AERoom.W9L1Uribe.value, player, world)
+    uribe = Region(AERoom.W9L1Uribe.value, player, multiworld)
     uribe.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], uribe) for loc_name in
                         get_array([193])]
-    gordo = Region(AERoom.W9L1Gordo.value, player, world)
+    gordo = Region(AERoom.W9L1Gordo.value, player, multiworld)
     gordo.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], gordo) for loc_name in
                         get_array([194])]
-    raeski = Region(AERoom.W9L1Raeski.value, player, world)
+    raeski = Region(AERoom.W9L1Raeski.value, player, multiworld)
     raeski.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], raeski) for loc_name in
                          get_array([195])]
-    poopie = Region(AERoom.W9L1Poopie.value, player, world)
+    poopie = Region(AERoom.W9L1Poopie.value, player, multiworld)
     poopie.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], poopie) for loc_name in
                          get_array([196])]
-    teacup = Region(AERoom.W9L1Teacup.value, player, world)
+    teacup = Region(AERoom.W9L1Teacup.value, player, multiworld)
     teacup.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], teacup) for loc_name in
                          get_array([197])]
-    shine = Region(AERoom.W9L1Shine.value, player, world)
+    shine = Region(AERoom.W9L1Shine.value, player, multiworld)
     shine.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], shine) for loc_name in
                         get_array([198])]
-    wrench = Region(AERoom.W9L1Wrench.value, player, world)
+    wrench = Region(AERoom.W9L1Wrench.value, player, multiworld)
     wrench.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], wrench) for loc_name in
                          get_array([199])]
-    bronson = Region(AERoom.W9L1Bronson.value, player, world)
+    bronson = Region(AERoom.W9L1Bronson.value, player, multiworld)
     bronson.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bronson) for loc_name in
                           get_array([200])]
-    bungee = Region(AERoom.W9L1Bungee.value, player, world)
+    bungee = Region(AERoom.W9L1Bungee.value, player, multiworld)
     bungee.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bungee) for loc_name in
                          get_array([201])]
-    carro = Region(AERoom.W9L1Carro.value, player, world)
+    carro = Region(AERoom.W9L1Carro.value, player, multiworld)
     carro.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], carro) for loc_name in
                         get_array([202])]
-    carlito = Region(AERoom.W9L1Carlito.value, player, world)
+    carlito = Region(AERoom.W9L1Carlito.value, player, multiworld)
     carlito.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], carlito) for loc_name in
                           get_array([203])]
-    bg = Region(AERoom.W9L1BG.value, player, world)
+    bg = Region(AERoom.W9L1BG.value, player, multiworld)
     bg.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], bg) for loc_name in
                      get_array([204])]
 
@@ -797,169 +799,169 @@ def create_regions(world: MultiWorld,options: ApeEscapeOptions, player: int):
                goopo, porto, slam, junk, crib, nak, cloy, shaw, flea, schafette, donovan, laura, uribe,
                gordo, raeski, poopie, teacup, shine, wrench, bronson, bungee, carro, carlito, bg]
 
-    if options.goal == 0x01:
+    if options.goal == "second":
         # 9-2
 
-        l92 = Region(AERoom.W9L2Boss.value, player, world)
+        l92 = Region(AERoom.W9L2Boss.value, player, multiworld)
         l92.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], l92) for loc_name in
                           get_array([206])]
         regions += [l92]
 
-    if options.coin == 0x00:
-        coin1 = Region(AERoom.Coin1.value, player, world)
+    if options.coin == "true":
+        coin1 = Region(AERoom.Coin1.value, player, multiworld)
         coin1.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin1) for loc_name
                             in get_array([301])]
-        coin2 = Region(AERoom.Coin2.value, player, world)
+        coin2 = Region(AERoom.Coin2.value, player, multiworld)
         coin2.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin2) for loc_name
                             in get_array([302])]
-        coin3 = Region(AERoom.Coin3.value, player, world)
+        coin3 = Region(AERoom.Coin3.value, player, multiworld)
         coin3.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin3) for loc_name
                             in get_array([303])]
-        coin6 = Region(AERoom.Coin6.value, player, world)
+        coin6 = Region(AERoom.Coin6.value, player, multiworld)
         coin6.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin6) for loc_name
                             in get_array([306])]
-        coin7 = Region(AERoom.Coin7.value, player, world)
+        coin7 = Region(AERoom.Coin7.value, player, multiworld)
         coin7.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin7) for loc_name
                             in get_array([307])]
-        coin8 = Region(AERoom.Coin8.value, player, world)
+        coin8 = Region(AERoom.Coin8.value, player, multiworld)
         coin8.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin8) for loc_name
                             in get_array([308])]
-        coin9 = Region(AERoom.Coin9.value, player, world)
+        coin9 = Region(AERoom.Coin9.value, player, multiworld)
         coin9.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin9) for loc_name
                             in get_array([309])]
-        coin11 = Region(AERoom.Coin11.value, player, world)
+        coin11 = Region(AERoom.Coin11.value, player, multiworld)
         coin11.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin11) for loc_name
                              in get_array([311])]
-        coin12 = Region(AERoom.Coin12.value, player, world)
+        coin12 = Region(AERoom.Coin12.value, player, multiworld)
         coin12.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin12) for loc_name
                              in get_array([312])]
-        coin13 = Region(AERoom.Coin13.value, player, world)
+        coin13 = Region(AERoom.Coin13.value, player, multiworld)
         coin13.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin13) for loc_name
                              in get_array([313])]
-        coin14 = Region(AERoom.Coin14.value, player, world)
+        coin14 = Region(AERoom.Coin14.value, player, multiworld)
         coin14.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin14) for loc_name
                              in get_array([314])]
-        coin17 = Region(AERoom.Coin17.value, player, world)
+        coin17 = Region(AERoom.Coin17.value, player, multiworld)
         coin17.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin17) for loc_name
                              in get_array([317])]
-        coin19 = Region(AERoom.Coin19.value, player, world)
+        coin19 = Region(AERoom.Coin19.value, player, multiworld)
         coin19.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin19) for loc_name
                              in get_array([295, 296, 297, 298, 299])]
-        coin21 = Region(AERoom.Coin21.value, player, world)
+        coin21 = Region(AERoom.Coin21.value, player, multiworld)
         coin21.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin21) for loc_name
                              in get_array([321])]
-        coin23 = Region(AERoom.Coin23.value, player, world)
+        coin23 = Region(AERoom.Coin23.value, player, multiworld)
         coin23.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin23) for loc_name
                              in get_array([323])]
-        coin24 = Region(AERoom.Coin24.value, player, world)
+        coin24 = Region(AERoom.Coin24.value, player, multiworld)
         coin24.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin24) for loc_name
                              in get_array([324])]
-        coin25 = Region(AERoom.Coin25.value, player, world)
+        coin25 = Region(AERoom.Coin25.value, player, multiworld)
         coin25.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin25) for loc_name
                              in get_array([325])]
-        coin28 = Region(AERoom.Coin28.value, player, world)
+        coin28 = Region(AERoom.Coin28.value, player, multiworld)
         coin28.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin28) for loc_name
                              in get_array([328])]
-        coin29 = Region(AERoom.Coin29.value, player, world)
+        coin29 = Region(AERoom.Coin29.value, player, multiworld)
         coin29.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin29) for loc_name
                              in get_array([329])]
-        coin30 = Region(AERoom.Coin30.value, player, world)
+        coin30 = Region(AERoom.Coin30.value, player, multiworld)
         coin30.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin30) for loc_name
                              in get_array([330])]
-        coin31 = Region(AERoom.Coin31.value, player, world)
+        coin31 = Region(AERoom.Coin31.value, player, multiworld)
         coin31.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin31) for loc_name
                              in get_array([331])]
-        coin32 = Region(AERoom.Coin32.value, player, world)
+        coin32 = Region(AERoom.Coin32.value, player, multiworld)
         coin32.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin32) for loc_name
                              in get_array([332])]
-        coin34 = Region(AERoom.Coin34.value, player, world)
+        coin34 = Region(AERoom.Coin34.value, player, multiworld)
         coin34.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin34) for loc_name
                              in get_array([334])]
-        coin35 = Region(AERoom.Coin35.value, player, world)
+        coin35 = Region(AERoom.Coin35.value, player, multiworld)
         coin35.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin35) for loc_name
                              in get_array([335])]
-        coin36 = Region(AERoom.Coin36.value, player, world)
+        coin36 = Region(AERoom.Coin36.value, player, multiworld)
         coin36.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin36) for loc_name
                              in get_array([290, 291, 292, 293, 294])]
-        coin37 = Region(AERoom.Coin37.value, player, world)
+        coin37 = Region(AERoom.Coin37.value, player, multiworld)
         coin37.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin37) for loc_name
                              in get_array([337])]
-        coin38 = Region(AERoom.Coin38.value, player, world)
+        coin38 = Region(AERoom.Coin38.value, player, multiworld)
         coin38.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin38) for loc_name
                              in get_array([338])]
-        coin39 = Region(AERoom.Coin39.value, player, world)
+        coin39 = Region(AERoom.Coin39.value, player, multiworld)
         coin39.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin39) for loc_name
                              in get_array([339])]
-        coin40 = Region(AERoom.Coin40.value, player, world)
+        coin40 = Region(AERoom.Coin40.value, player, multiworld)
         coin40.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin40) for loc_name
                              in get_array([340])]
-        coin41 = Region(AERoom.Coin41.value, player, world)
+        coin41 = Region(AERoom.Coin41.value, player, multiworld)
         coin41.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin41) for loc_name
                              in get_array([341])]
-        coin43 = Region(AERoom.Coin43.value, player, world)
+        coin43 = Region(AERoom.Coin43.value, player, multiworld)
         coin43.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin43) for loc_name
                              in get_array([343])]
-        coin45 = Region(AERoom.Coin45.value, player, world)
+        coin45 = Region(AERoom.Coin45.value, player, multiworld)
         coin45.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin45) for loc_name
                              in get_array([345])]
-        coin46 = Region(AERoom.Coin46.value, player, world)
+        coin46 = Region(AERoom.Coin46.value, player, multiworld)
         coin46.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin46) for loc_name
                              in get_array([346])]
-        coin49 = Region(AERoom.Coin49.value, player, world)
+        coin49 = Region(AERoom.Coin49.value, player, multiworld)
         coin49.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin49) for loc_name
                              in get_array([349])]
-        coin50 = Region(AERoom.Coin50.value, player, world)
+        coin50 = Region(AERoom.Coin50.value, player, multiworld)
         coin50.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin50) for loc_name
                              in get_array([350])]
-        coin53 = Region(AERoom.Coin53.value, player, world)
+        coin53 = Region(AERoom.Coin53.value, player, multiworld)
         coin53.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin53) for loc_name
                              in get_array([353])]
-        coin54 = Region(AERoom.Coin54.value, player, world)
+        coin54 = Region(AERoom.Coin54.value, player, multiworld)
         coin54.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin54) for loc_name
                              in get_array([354])]
-        coin55 = Region(AERoom.Coin55.value, player, world)
+        coin55 = Region(AERoom.Coin55.value, player, multiworld)
         coin55.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin55) for loc_name
                              in get_array([355])]
-        coin58 = Region(AERoom.Coin58.value, player, world)
+        coin58 = Region(AERoom.Coin58.value, player, multiworld)
         coin58.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin58) for loc_name
                              in get_array([358])]
-        coin62 = Region(AERoom.Coin62.value, player, world)
+        coin62 = Region(AERoom.Coin62.value, player, multiworld)
         coin62.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin62) for loc_name
                              in get_array([362])]
-        coin64 = Region(AERoom.Coin64.value, player, world)
+        coin64 = Region(AERoom.Coin64.value, player, multiworld)
         coin64.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin64) for loc_name
                              in get_array([364])]
-        coin66 = Region(AERoom.Coin66.value, player, world)
+        coin66 = Region(AERoom.Coin66.value, player, multiworld)
         coin66.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin66) for loc_name
                              in get_array([366])]
-        coin73 = Region(AERoom.Coin73.value, player, world)
+        coin73 = Region(AERoom.Coin73.value, player, multiworld)
         coin73.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin73) for loc_name
                              in get_array([373])]
-        coin74 = Region(AERoom.Coin74.value, player, world)
+        coin74 = Region(AERoom.Coin74.value, player, multiworld)
         coin74.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin74) for loc_name
                              in get_array([374])]
-        coin75 = Region(AERoom.Coin75.value, player, world)
+        coin75 = Region(AERoom.Coin75.value, player, multiworld)
         coin75.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin75) for loc_name
                              in get_array([375])]
-        coin77 = Region(AERoom.Coin77.value, player, world)
+        coin77 = Region(AERoom.Coin77.value, player, multiworld)
         coin77.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin77) for loc_name
                              in get_array([377])]
-        coin78 = Region(AERoom.Coin78.value, player, world)
+        coin78 = Region(AERoom.Coin78.value, player, multiworld)
         coin78.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin78) for loc_name
                              in get_array([378])]
-        coin79 = Region(AERoom.Coin79.value, player, world)
+        coin79 = Region(AERoom.Coin79.value, player, multiworld)
         coin79.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin79) for loc_name
                              in get_array([379])]
-        coin80 = Region(AERoom.Coin80.value, player, world)
+        coin80 = Region(AERoom.Coin80.value, player, multiworld)
         coin80.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin80) for loc_name
                              in get_array([380])]
-        coin82 = Region(AERoom.Coin82.value, player, world)
+        coin82 = Region(AERoom.Coin82.value, player, multiworld)
         coin82.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin82) for loc_name
                              in get_array([382])]
-        coin84 = Region(AERoom.Coin84.value, player, world)
+        coin84 = Region(AERoom.Coin84.value, player, multiworld)
         coin84.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin84) for loc_name
                              in get_array([384])]
-        coin85 = Region(AERoom.Coin85.value, player, world)
+        coin85 = Region(AERoom.Coin85.value, player, multiworld)
         coin85.locations += [ApeEscapeLocation(player, loc_name, location_table[loc_name], coin85) for loc_name
                              in get_array([385])]
         regions += [coin1, coin2, coin3, coin6, coin7, coin8, coin9, coin11, coin12, coin13, coin14, coin17, coin19,
@@ -968,24 +970,24 @@ def create_regions(world: MultiWorld,options: ApeEscapeOptions, player: int):
                     coin55, coin58, coin62, coin64, coin66, coin73, coin74, coin75, coin77, coin78, coin79, coin80,
                     coin82, coin84, coin85]
 
-    world.regions.extend(regions)
+    multiworld.regions.extend(regions)
 
 
-def connect_regions(world: MultiWorld, player: int, source: str, target: str, rule=None):
-    sourceRegion = world.get_region(source, player)
-    targetRegion = world.get_region(target, player)
+def connect_regions(world: "ApeEscapeWorld", source: str, target: str, rule=None):
+    source_region = world.get_region(source)
+    target_region = world.get_region(target)
 
-    connection = Entrance(player, source + '_to_' + target, sourceRegion)
+    connection = Entrance(world.player, source + "_to_" + target, source_region)
     if rule:
         connection.access_rule = rule
 
-    sourceRegion.exits.append(connection)
-    connection.connect(targetRegion)
+    source_region.exits.append(connection)
+    connection.connect(target_region)
 
 
 def get_range(i, j):
-    i = i + 128000000
-    j = j + 128000000
+    i += 128000000
+    j += 128000000
     res = dict()
     for key, val in location_table.items():
         if i <= int(val) <= j:

--- a/worlds/apeescape/Rules.py
+++ b/worlds/apeescape/Rules.py
@@ -1,17 +1,17 @@
-from worlds.apeescape import location_table
-from worlds.generic.Rules import add_rule, set_rule, forbid_item
-from BaseClasses import LocationProgressType
-from .Regions import connect_regions
-from .Strings import AEItem, AEWorld, AERoom
-from .RulesGlitchless import Glitchless
-from .RulesNoIJ import NoIJ
-from .RulesIJ import IJ
+from typing import TYPE_CHECKING
+
+from .RulesGlitchless import set_glitchless_rules
+from .RulesNoIJ import set_noij_rules
+from .RulesIJ import set_ij_rules
+
+if TYPE_CHECKING:
+    from . import ApeEscapeWorld
 
 
-def set_rules(world, player: int):
-    if world.logic[player].value == 0x00:
-        Glitchless.set_rules(None, world, player, world.coin[player].value == 0x00)
-    elif world.logic[player].value == 0x01:
-        NoIJ.set_rules(None, world, player, world.coin[player].value == 0x00)
-    elif world.logic[player].value == 0x02:
-        IJ.set_rules(None, world, player, world.coin[player].value == 0x00)
+def set_rules(world: "ApeEscapeWorld"):
+    if world.options.logic == "glitchless":
+        set_glitchless_rules(world)
+    elif world.options.logic == "noij":
+        set_noij_rules(world)
+    elif world.options.logic == "ij":
+        set_ij_rules(world)

--- a/worlds/apeescape/RulesGlitchless.py
+++ b/worlds/apeescape/RulesGlitchless.py
@@ -1,888 +1,883 @@
-from worlds.apeescape import location_table
-from worlds.generic.Rules import add_rule, set_rule, forbid_item
-from BaseClasses import LocationProgressType
 from .Regions import connect_regions
-from .Options import SuperFlyerOption
 from .Strings import AEItem, AEWorld, AERoom
 
 
-class Glitchless():
-    def set_rules(self, world, player: int, coins: bool):
+def set_glitchless_rules(self):
+    # Worlds
+    connect_regions(self, "Menu", AEWorld.W1.value, lambda state: NoRequirement())
+    connect_regions(self, "Menu", AEWorld.W2.value, lambda state: Keys(state, self, 1))
+    connect_regions(self, "Menu", AEWorld.W3.value,
+                    lambda state: CanSwim(state, self) and Keys(state, self, 2))
+    connect_regions(self, "Menu", AEWorld.W4.value, lambda state: Keys(state, self, 2))
+    connect_regions(self, "Menu", AEWorld.W5.value, lambda state: Keys(state, self, 3))
+    connect_regions(self, "Menu", AEWorld.W6.value,
+                    lambda state: HasFlyer(state, self) and Keys(state, self, 4))
+    connect_regions(self, "Menu", AEWorld.W7.value, lambda state: Keys(state, self, 4))
+    connect_regions(self, "Menu", AEWorld.W8.value, lambda state: Keys(state, self, 5))
+    connect_regions(self, "Menu", AEWorld.W9.value, lambda state: Keys(state, self, 6))
 
-        # Worlds
-        connect_regions(world, player, "Menu", AEWorld.W1.value, lambda state: NoRequirement())
-        connect_regions(world, player, "Menu", AEWorld.W2.value, lambda state: Keys(state, player, 1))
-        connect_regions(world, player, "Menu", AEWorld.W3.value,
-                        lambda state: CanSwim(state, player) and Keys(state, player, 2))
-        connect_regions(world, player, "Menu", AEWorld.W4.value, lambda state: Keys(state, player, 2))
-        connect_regions(world, player, "Menu", AEWorld.W5.value, lambda state: Keys(state, player, 3))
-        connect_regions(world, player, "Menu", AEWorld.W6.value,
-                        lambda state: HasFlyer(state, player) and Keys(state, player, 4))
-        connect_regions(world, player, "Menu", AEWorld.W7.value, lambda state: Keys(state, player, 4))
-        connect_regions(world, player, "Menu", AEWorld.W8.value, lambda state: Keys(state, player, 5))
-        connect_regions(world, player, "Menu", AEWorld.W9.value, lambda state: Keys(state, player, 6))
+    if self.options.goal == "second":
+        connect_regions(self, "Menu", AERoom.W9L2Boss.value,
+                        lambda state: Keys(state, self, 6) and HasSling(state, self)
+                                      and HasHoop(state, self) and HasFlyer(state, self)
+                                      and CanHitMultiple(state, self) and HasRC(state, self))
 
-        if world.goal[player].value == 0x01:
-            connect_regions(world, player, "Menu", AERoom.W9L2Boss.value,
-                            lambda state: Keys(state, player, 6) and HasSling(state, player) and HasHoop(state,
-                                                                                                         player) and HasFlyer(
-                                state, player) and CanHitMultiple(state, player) and HasRC(state, player))
+    # 1-1
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
 
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Noonan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Jorjy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Nati.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value,
+                    lambda state: HasFlyer(state, self))
+
+    # 1-2
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L2Main.value, lambda state: True)
+
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Shay.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2DrMonk.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Grunt.value,
+                    lambda state: CanSwim(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Ahchoo.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Gornif.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Tyrone.value, lambda state: NoRequirement())
+
+    # 1-3
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L3Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Volcano.value, lambda state: True)
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Triceratops.value,
+                    lambda state: HasSling(state, self))
+
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Scotty.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Coco.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3JThomas.value,
+                    lambda state: CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Moggan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Volcano.value, AERoom.W1L3Barney.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Volcano.value, AERoom.W1L3Mattie.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Triceratops.value, AERoom.W1L3Rocky.value,
+                    lambda state: HasSling(state, self) and CanHitMultiple(state, self))
+
+    # 2-1
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L1Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Mushroom.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Fish.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Tent.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Boulder.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Marquez.value,
+                    lambda state: CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Livinston.value,
+                    lambda state: CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1George.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Gonzo.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Zanzibar.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
+                    lambda state: TJ_FishEntry(state, self) and HasSling(state, self))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
+                    lambda state: TJ_FishEntry(state, self))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Stoddy.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Mitong.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
+                    lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self)
+                                                                  and TJ_UFOCliff(state, self)))
+                                   and CanHitMultiple(state, self)))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value,
+                    lambda state: (TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self))
+                                   and CanHitMultiple(state, self)) and HasSling(state, self))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value,
+                    lambda state: ((TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))
+                                   or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self))
+                                  and HasSling(state, self))
+
+    # 2-2
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Fan.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Obelisk.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Water.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Kyle.value,
+                    lambda state: CanHitOnce(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Stan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Kenny.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Cratman.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Mooshy.value,
+                    lambda state: HasHoop(state, self))
+    connect_regions(self, AERoom.W2L2Fan.value, AERoom.W2L2Nuzzy.value,
+                    lambda state: HasSling(state, self) or HasHoop(state, self) or HasPunch(state, self))
+    connect_regions(self, AERoom.W2L2Fan.value, AERoom.W2L2Mav.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Papou.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Trance.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
+                    lambda state: HasSling(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
+                    lambda state: CanSwim(state, self) and (HasSling(state, self) or HasHoop(state, self))
+                                  and (CanHitOnce(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
+                    lambda state: CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
+                    lambda state: CanSwim(state, self) and (HasSling(state, self) or HasHoop(state, self))
+                                  and (CanHitOnce(state, self) or HasFlyer(state, self)))
+
+    # 2-3
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Side.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Main.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Pillar.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Bazzle.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Freeto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L3Side.value, AERoom.W2L3Troopa.value,
+                    lambda state: (HasSling(state, self) or (HasFlyer(state, self)
+                                                             and CanHitOnce(state, self))))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
+                    lambda state: CR_Inside(state, self))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
+                    lambda state: CR_Inside(state, self) and CanSwim(state, self) and (
+                            HasFlyer(state, self) or CanHitMultiple(state, self)))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
+                    lambda state: CR_Inside(state, self) and (CanHitMultiple(state, self) or (
+                            CanSwim(state, self) and HasMobility(state, self))))
+    connect_regions(self, AERoom.W2L3Pillar.value, AERoom.W2L3Pally.value,
+                    lambda state: CR_Inside(state, self))
+    connect_regions(self, AERoom.W2L3Pillar.value, AERoom.W2L3Crash.value,
+                    lambda state: CR_Inside(state, self) and RCMonkey(state, self))
+
+    # 4-1
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L1FirstRoom.value, lambda state: True)
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1SecondRoom.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1CoolBlue.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1Sandy.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1ShellE.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1Gidget.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Shaka.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Puka.value,
+                    lambda state: CanHitMultiple(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1MaxMahalo.value,
+                    lambda state: HasSling(state, self) and HasFlyer(state, self))
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Moko.value,
+                    lambda state: HasFlyer(state, self))
+
+    # 4-2
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L2FirstRoom.value, lambda state: True)
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2SecondRoom.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Chip.value,
+                    lambda state: CanSwim(state, self) and CanWaterCatch(state, self))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
+                    lambda state: (HasHoop(state, self) and CanHitMultiple(state, self)
+                                   and CanSwim(state, self)) or HasMobility(state, self))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
+                    lambda state: CanDive(state, self))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value,
+                    lambda state: (HasHoop(state, self) and CanHitMultiple(state, self) and CanSwim(state, self))
+                                  or HasMobility(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2BongBong.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Jux.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Pickles.value,
+                    lambda state: CanSwim(state, self) and CanHitMultiple(state, self))
+
+    # 4-3
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3Stomach.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Slide.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Slide.value, AERoom.W4L3Gallery.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Tentacle.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3TonTon.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3Stuw.value,
+                    lambda state: CanSwim(state, self) or CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Mars.value,
+                    lambda state: CanHitOnce(state, self) and HasRC(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Murky.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Horke.value,
+                    lambda state: CanHitOnce(state, self) and (CanSwim(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Howeerd.value,
+                    lambda state: DI_SecondHalf(state, self) and HasSling(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Robbin.value,
+                    lambda state: DI_SecondHalf(state, self) and HasSling(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Jakkee.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Frederic.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Baba.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Tentacle.value, AERoom.W4L3Quirck.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+
+    # 5-1
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L1Main.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Popcicle.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
+                    lambda state: HasSling(state, self))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value,
+                    lambda state: CanHitMultiple(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value,
+                    lambda state: CanHitMultiple(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value,
+                    lambda state: CanHitMultiple(state, self) or HasFlyer(state, self))
+
+    # 5-2
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L2Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Water.value, lambda state: True)
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Caverns.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Storm.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Qube.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Ranix.value,
+                    lambda state: HasFlyer(state, self) and HasSling(state, self))
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sharpe.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sticky.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Droog.value,
+                    lambda state: HasFlyer(state, self) and CanDive(state, self))
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Gash.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Kundra.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Shadow.value,
+                    lambda state: HasFlyer(state, self))
+
+    # 5-3
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Spring.value, lambda state: True)
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Cave.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Punky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Ameego.value,
+                    lambda state: CanDive(state, self))
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Yoky.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Jory.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Crank.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Claxter.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Looza.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Cave.value, AERoom.W5L3Roti.value,
+                    lambda state: CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W5L3Cave.value, AERoom.W5L3Dissa.value,
+                    lambda state: CanHitMultiple(state, self))
+
+    # 7-1
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Temple.value, lambda state: True)
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Well.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Taku.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Rocka.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Wog.value,
+                    lambda state: HasSling(state, self))
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Mayi.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Owyang.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Long.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Elly.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
+                    lambda state: HasSling(state, self))
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
+
+    # 7-2
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L2First.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Gong.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Middle.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Middle.value, AERoom.W7L2Course.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Barrel.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Minky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Zobbro.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Xeeto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Moops.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Zanabi.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Middle.value, AERoom.W7L2Doxs.value,
+                    lambda state: WSW_ThirdRoom(state, self))
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Buddha.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self))
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
+                    lambda state: WSW_ThirdRoom(state, self) and RCMonkey(state, self))
+    connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self)
+                                  and HasSling(state, self))
+    connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
+                            HasSling(state, self) or HasFlyer(state, self)))
+
+    # 7-3
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Castle.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Basement.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Button.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Elevator.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Bell.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Robart.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Igor.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Naners.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Neeners.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Charles.value,
+                    lambda state: HasPunch(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Gustav.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Wilhelm.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Emmanuel.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3SirCutty.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Calligan.value,
+                    lambda state: CC_WaterRoom(state, self) and (
+                            CanDive(state, self) or HasPunch(state, self)))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Castalist.value,
+                    lambda state: CC_WaterRoom(state, self) and CanDive(state, self))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Deveneom.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Button.value, AERoom.W7L3Astur.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Button.value, AERoom.W7L3Kilserack.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Ringo.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Densil.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Figero.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Fej.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Joey.value,
+                    lambda state: HasMobility(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Donqui.value, lambda state: NoRequirement())
+
+    # 8-1
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Sewers.value, lambda state: True)
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Barrel.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value,
+                    lambda state: RCMonkey(state, self))
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
+                    lambda state: CP_FrontBarrels(state, self) and CanDive(state, self)
+                                  and HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
+                    lambda state: CP_FrontSewer(state, self) and HasRC(state, self))
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
+                    lambda state: CP_FrontSewer(state, self) and HasRC(state, self))
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
+                    lambda state: CP_FrontSewer(state, self) and HasRC(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
+                    lambda state: CP_FrontBarrels(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
+                    lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self)
+                                  and CanDive(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
+                    lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
+                    lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
+                    lambda state: CP_FrontBarrels(state, self) and CanDive(state, self)
+                                  and HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
+                    lambda state: CP_FrontBarrels(state, self) and CanSwim(state, self)
+                                  and HasFlyer(state, self))
+
+    # 8-2
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2Factory.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2RC.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Mech.value, AERoom.W8L2Lava.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Conveyor.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2Mech.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2BigShow.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2Dreos.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2Reznor.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2RC.value, AERoom.W8L2Urkel.value,
+                    lambda state: SF_CarRoom(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2VanillaS.value,
+                    lambda state: SF_MechRoom(state, self) and HasPunch(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Radd.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Shimbo.value,
+                    lambda state: SF_MechRoom(state, self) and RCMonkey(state, self))
+    connect_regions(self, AERoom.W8L2Conveyor.value, AERoom.W8L2Hurt.value,
+                    lambda state: SF_MechRoom(state, self) and CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W8L2Conveyor.value, AERoom.W8L2String.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2Mech.value, AERoom.W8L2Khamo.value,
+                    lambda state: SF_MechRoom(state, self) and CanHitMultiple(state, self))
+
+    # 8-3
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Water.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Outside.value, AERoom.W8L3Lobby.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Tank.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Fan.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L3Outside.value, AERoom.W8L3Fredo.value,
+                    lambda state: HasPunch(state, self))
+    connect_regions(self, AERoom.W8L3Water.value, AERoom.W8L3Charlee.value,
+                    lambda state: TVT_HitButton(state, self) and HasSling(state, self))
+    connect_regions(self, AERoom.W8L3Water.value, AERoom.W8L3Mach3.value,
+                    lambda state: TVT_HitButton(state, self))
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Tortuss.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Manic.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Ruptdis.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Eighty7.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Danio.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Roosta.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Tellis.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Whack.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Frostee.value,
+                    lambda state: TVT_TankRoom(state, self))
+
+    # 9-1
+    connect_regions(self, AEWorld.W9.value, AERoom.W9L1Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Haunted.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Haunted.value, AERoom.W9L1Coffin.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Natalie.value,
+                    lambda state: MM_Natalie(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Professor.value,
+                    lambda state: MM_Professor(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Jake.value,
+                    lambda state: MM_Jake(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Western.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Crater.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Crater.value, AERoom.W9L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Castle.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Climb1.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Climb2.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Head.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Side.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Boss.value,
+                    lambda state: MM_FinalBoss(state, self))
+
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Goopo.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Haunted.value, AERoom.W9L1Porto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Slam.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Junk.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Crib.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Nak.value,
+                    lambda state: HasSling(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Cloy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Shaw.value,
+                    lambda state: HasSling(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Flea.value,
+                    lambda state: HasSling(state, self))
+    connect_regions(self, AERoom.W9L1Crater.value, AERoom.W9L1Schafette.value,
+                    lambda state: MM_SHA(state, self) and HasFlyer(state, self))
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Donovan.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Laura.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Uribe.value,
+                    lambda state: MM_UFODoor(state, self) and HasPunch(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Gordo.value,
+                    lambda state: MM_UFODoor(state, self) and HasRC(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Raeski.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Poopie.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Teacup.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Shine.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb2.value, AERoom.W9L1Wrench.value,
+                    lambda state: MM_SpaceMonkeys(state, self))
+    connect_regions(self, AERoom.W9L1Climb2.value, AERoom.W9L1Bronson.value,
+                    lambda state: MM_SpaceMonkeys(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Bungee.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Carro.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Carlito.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Side.value, AERoom.W9L1BG.value,
+                    lambda state: MM_SHA(state, self) and HasSling(state, self) and HasFlyer(state, self))
+
+    self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player, 1)
+
+    if self.options.coin == "true":
+        # Coins
         # 1-1
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Noonan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Jorjy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Nati.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value,
-                        lambda state: HasFlyer(state, player))
-
+        connect_regions(self, AERoom.W1L1Main.value, AERoom.Coin1.value, lambda state: NoRequirement())
         # 1-2
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L2Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Shay.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2DrMonk.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Grunt.value,
-                        lambda state: CanSwim(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Ahchoo.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Gornif.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Tyrone.value, lambda state: NoRequirement())
-
+        connect_regions(self, AERoom.W1L2Main.value, AERoom.Coin2.value,
+                        lambda state: CanDive(state, self))
         # 1-3
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L3Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Volcano.value, lambda state: True)
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Triceratops.value,
-                        lambda state: HasSling(state, player))
-
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Scotty.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Coco.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3JThomas.value,
-                        lambda state: CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Moggan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Volcano.value, AERoom.W1L3Barney.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Volcano.value, AERoom.W1L3Mattie.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Triceratops.value, AERoom.W1L3Rocky.value,
-                        lambda state: HasSling(state, player) and CanHitMultiple(state, player))
-
+        connect_regions(self, AERoom.W1L3Entry.value, AERoom.Coin3.value, lambda state: NoRequirement())
         # 2-1
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L1Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Mushroom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Fish.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Tent.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Boulder.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Marquez.value,
-                        lambda state: CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Livinston.value,
-                        lambda state: CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1George.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Gonzo.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Zanzibar.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
-                        lambda state: TJ_FishEntry(state, player) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
-                        lambda state: TJ_FishEntry(state, player))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Stoddy.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Mitong.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
-                        lambda state: ((TJ_FishEntry(state, player) or (TJ_UFOEntry(state, player)
-                                                                        and TJ_UFOCliff(state, player)))
-                                       and CanHitMultiple(state, player)))
-        connect_regions(world, player, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value,
-                        lambda state: (TJ_UFOEntry(state, player) or (TJ_FishEntry(state, player))
-                                       and CanHitMultiple(state, player)) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value,
-                        lambda state: ((TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player))
-                                       or (TJ_FishEntry(state, player)) and CanHitMultiple(state, player))
-                        and HasSling(state, player))
-
+        connect_regions(self, AERoom.W2L1Entry.value, AERoom.Coin6.value,
+                        lambda state: HasMobility(state, self))
+        connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.Coin7.value,
+                        lambda state: TJ_Mushroom(state, self))
+        connect_regions(self, AERoom.W2L1Fish.value, AERoom.Coin8.value,
+                        lambda state: (TJ_FishEntry(state, self)))
+        connect_regions(self, AERoom.W2L1Tent.value, AERoom.Coin9.value,
+                        lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                                (TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
         # 2-2
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Fan.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Obelisk.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Water.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Kyle.value,
-                        lambda state: CanHitOnce(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Stan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Kenny.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Cratman.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Mooshy.value,
-                        lambda state: HasHoop(state, player))
-        connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.W2L2Nuzzy.value,
-                        lambda state: HasSling(state, player) or HasHoop(state, player) or HasPunch(state, player))
-        connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.W2L2Mav.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Papou.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Trance.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
-                        lambda state: HasSling(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
-                        lambda state: CanSwim(state, player) and (HasSling(state, player) or HasHoop(state, player))
-                        and (CanHitOnce(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
-                        lambda state: CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
-                        lambda state: CanSwim(state, player) and (HasSling(state, player) or HasHoop(state, player))
-                        and (CanHitOnce(state, player) or HasFlyer(state, player)))
-
+        connect_regions(self, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
+                        lambda state: HasRC(state, self) or HasPunch(state, self))
+        connect_regions(self, AERoom.W2L2Water.value, AERoom.Coin14.value,
+                        lambda state: (CanDive(state, self)) and (
+                                (CanHitOnce(state, self)) or (HasFlyer(state, self))))
         # 2-3
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Side.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Main.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Pillar.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Bazzle.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Freeto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L3Side.value, AERoom.W2L3Troopa.value,
-                        lambda state: (HasSling(state, player) or (HasFlyer(state, player)
-                                                                   and CanHitOnce(state, player))))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
-                        lambda state: CR_Inside(state, player))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
-                        lambda state: CR_Inside(state, player) and CanSwim(state, player) and (
-                                HasFlyer(state, player) or CanHitMultiple(state, player)))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
-                        lambda state: CR_Inside(state, player) and (CanHitMultiple(state, player) or (
-                                CanSwim(state, player) and HasMobility(state, player))))
-        connect_regions(world, player, AERoom.W2L3Pillar.value, AERoom.W2L3Pally.value,
-                        lambda state: CR_Inside(state, player))
-        connect_regions(world, player, AERoom.W2L3Pillar.value, AERoom.W2L3Crash.value,
-                        lambda state: CR_Inside(state, player) and RCMonkey(state, player))
+        connect_regions(self, AERoom.W2L3Main.value, AERoom.Coin17.value,
+                        lambda state: (CR_Inside(state, self)) and (
+                                (CanHitMultiple(state, self)) and (CanSwim(state, self))) or (
+                                          HasMobility(state, self)))
+        # 3-1
+        connect_regions(self, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, self))
 
         # 4-1
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L1FirstRoom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1SecondRoom.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1CoolBlue.value,
+        connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.Coin21.value,
                         lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1Sandy.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1ShellE.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1Gidget.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Shaka.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Puka.value,
-                        lambda state: CanHitMultiple(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1MaxMahalo.value,
-                        lambda state: HasSling(state, player) and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Moko.value,
-                        lambda state: HasFlyer(state, player))
 
         # 4-2
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L2FirstRoom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2SecondRoom.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Chip.value,
-                        lambda state: CanSwim(state, player) and CanWaterCatch(state, player))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
-                        lambda state: (HasHoop(state, player) and CanHitMultiple(
-                            state, player) and CanSwim(state, player)) or HasMobility(state, player))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
-                        lambda state: CanDive(state, player))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value, lambda state: (HasHoop(
-            state, player) and CanHitMultiple(state, player) and CanSwim(state, player)) or HasMobility(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2BongBong.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Jux.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Pickles.value,
-                        lambda state: CanSwim(state, player) and CanHitMultiple(state, player))
+        connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.Coin23.value,
+                        lambda state: CanDive(state, self))
 
         # 4-3
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3Stomach.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Slide.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Slide.value, AERoom.W4L3Gallery.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Tentacle.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3TonTon.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3Stuw.value,
-                        lambda state: CanSwim(state, player) or CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Mars.value,
-                        lambda state: CanHitOnce(state, player) and HasRC(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Murky.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Horke.value,
-                        lambda state: CanHitOnce(state, player) and (CanSwim(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Howeerd.value,
-                        lambda state: DI_SecondHalf(state, player) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Robbin.value,
-                        lambda state: DI_SecondHalf(state, player) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Jakkee.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Frederic.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Baba.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Tentacle.value, AERoom.W4L3Quirck.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
+        connect_regions(self, AERoom.W4L3Outside.value, AERoom.Coin24.value,
+                        lambda state: CanSwim(state, self) or CanHitOnce(state, self))
+        connect_regions(self, AERoom.W4L3Stomach.value, AERoom.Coin25.value,
+                        lambda state: CanDive(state, self) and CanHitOnce(state, self))
+        connect_regions(self, AERoom.W4L3Slide.value, AERoom.Coin28.value,
+                        lambda state: (CanSwim(state, self)) and (
+                                (CanHitOnce(state, self)) or (HasPunch(state, self))))
+        # Punch or Net, if Net is shuffled.
 
         # 5-1
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L1Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Popcicle.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
-                        lambda state: HasSling(state, player))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value,
-                        lambda state: CanHitMultiple(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value,
-                        lambda state: CanHitMultiple(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value,
-                        lambda state: CanHitMultiple(state, player) or HasFlyer(state, player))
+        connect_regions(self, AERoom.W5L1Main.value, AERoom.Coin29.value,
+                        lambda state: NoRequirement())
 
         # 5-2
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L2Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Water.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Caverns.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Storm.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Qube.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Ranix.value,
-                        lambda state: HasFlyer(state, player) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Sharpe.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Sticky.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Droog.value,
-                        lambda state: HasFlyer(state, player) and CanDive(state, player))
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Gash.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Kundra.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Shadow.value,
-                        lambda state: HasFlyer(state, player))
+        connect_regions(self, AERoom.W5L2Entry.value, AERoom.Coin30.value,
+                        lambda state: HasFlyer(state, self))
+        connect_regions(self, AERoom.W5L2Water.value, AERoom.Coin31.value,
+                        lambda state: HasFlyer(state, self) and CanDive(state, self))
+        connect_regions(self, AERoom.W5L2Caverns.value, AERoom.Coin32.value,
+                        lambda state: HasFlyer(state, self))
 
         # 5-3
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Spring.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Cave.value, lambda state: True)
+        connect_regions(self, AERoom.W5L3Spring.value, AERoom.Coin34.value,
+                        lambda state: HasFlyer(state, self))
+        connect_regions(self, AERoom.W5L3Cave.value, AERoom.Coin35.value,
+                        lambda state: CanHitMultiple(state, self))
 
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Punky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Ameego.value,
-                        lambda state: CanDive(state, player))
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Yoky.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Jory.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Crank.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Claxter.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Looza.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.W5L3Roti.value,
-                        lambda state: CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.W5L3Dissa.value,
-                        lambda state: CanHitMultiple(state, player))
+        # 6-1
+        connect_regions(self, AEWorld.W6.value, AERoom.Coin36.value, lambda state: HasFlyer(state, self))
 
         # 7-1
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Temple.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Well.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Taku.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Rocka.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value,
+        connect_regions(self, AERoom.W7L1Outside.value, AERoom.Coin37.value,
                         lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Wog.value,
-                        lambda state: HasSling(state, player))
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Mayi.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Owyang.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Long.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Elly.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
-                        lambda state: HasSling(state, player))
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L1Temple.value, AERoom.Coin38.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L1Well.value, AERoom.Coin39.value,
+                        lambda state: HasFlyer(state, self))
 
         # 7-2
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L2First.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Gong.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Middle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Middle.value, AERoom.W7L2Course.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Barrel.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Minky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Zobbro.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Xeeto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Moops.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Zanabi.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Middle.value, AERoom.W7L2Doxs.value,
-                        lambda state: WSW_ThirdRoom(state, player))
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Buddha.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player))
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
-                        lambda state: WSW_ThirdRoom(state, player) and RCMonkey(state, player))
-        connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player)
-                        and HasSling(state,player))
-        connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player) and (
-                                HasSling(state, player) or HasFlyer(state, player)))
+        connect_regions(self, AERoom.W7L2First.value, AERoom.Coin40.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L2Gong.value, AERoom.Coin41.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L2Barrel.value, AERoom.Coin43.value,
+                        lambda state: HasFlyer(state, self))
 
         # 7-3
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Castle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Basement.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Button.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Elevator.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Bell.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Robart.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Igor.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Naners.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Neeners.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Charles.value,
-                        lambda state: HasPunch(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Gustav.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Wilhelm.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Emmanuel.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3SirCutty.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Calligan.value,
-                        lambda state: CC_WaterRoom(state, player) and (
-                                CanDive(state, player) or HasPunch(state, player)))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Castalist.value,
-                        lambda state: CC_WaterRoom(state, player) and CanDive(state, player))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Deveneom.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Button.value, AERoom.W7L3Astur.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Button.value, AERoom.W7L3Kilserack.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Ringo.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Densil.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Figero.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Fej.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Joey.value,
-                        lambda state: HasMobility(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Donqui.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L3Outside.value, AERoom.Coin45.value,
+                        lambda state: HasClub(state, self) or HasFlyer(state, self) or HasPunch(state, self))
+        connect_regions(self, AERoom.W7L3Castle.value, AERoom.Coin46.value,
+                        lambda state: CC_5Monkeys(state, self))
+        connect_regions(self, AERoom.W7L3Button.value, AERoom.Coin49.value,
+                        lambda state: CC_ButtonRoom(state, self))
+        connect_regions(self, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
+                        lambda state: CC_5Monkeys(state, self) or CC_WaterRoom(state, self))
 
         # 8-1
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Sewers.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1Barrel.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value,
-                        lambda state: RCMonkey(state, player))
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
-                        lambda state: CP_FrontBarrels(state, player) and CanDive(state, player)
-                        and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
-                        lambda state: CP_FrontSewer(state, player) and HasRC(state, player))
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
-                        lambda state: CP_FrontSewer(state, player) and HasRC(state, player))
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
-                        lambda state: CP_FrontSewer(state, player) and HasRC(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
-                        lambda state: CP_FrontBarrels(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
-                        lambda state: CP_FrontBarrels(state, player) and HasFlyer(state, player)
-                        and CanDive(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
-                        lambda state: CP_FrontBarrels(state, player) and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
-                        lambda state: CP_FrontBarrels(state, player) and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
-                        lambda state: CP_FrontBarrels(state, player) and CanDive(state, player)
-                        and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
-                        lambda state: CP_FrontBarrels(state, player) and CanSwim(state, player)
-                        and HasFlyer(state, player))
+        connect_regions(self, AERoom.W8L1Outside.value, AERoom.Coin53.value,
+                        lambda state: CP_FrontBarrels(state, self) and CanDive(state, self)
+                                      and HasFlyer(state, self))
+        connect_regions(self, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
+                        lambda state: CP_FrontSewer(state, self) and HasRC(state, self))
+        connect_regions(self, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
+                        lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self))
 
         # 8-2
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2Factory.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2RC.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Mech.value, AERoom.W8L2Lava.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Conveyor.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2Mech.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2BigShow.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2Dreos.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2Reznor.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2RC.value, AERoom.W8L2Urkel.value,
-                        lambda state: SF_CarRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2VanillaS.value,
-                        lambda state: SF_MechRoom(state, player) and HasPunch(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Radd.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Shimbo.value,
-                        lambda state: SF_MechRoom(state, player) and RCMonkey(state, player))
-        connect_regions(world, player, AERoom.W8L2Conveyor.value, AERoom.W8L2Hurt.value,
-                        lambda state: SF_MechRoom(state, player) and CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W8L2Conveyor.value, AERoom.W8L2String.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2Mech.value, AERoom.W8L2Khamo.value,
-                        lambda state: SF_MechRoom(state, player) and CanHitMultiple(state, player))
+        connect_regions(self, AERoom.W8L2RC.value, AERoom.Coin58.value,
+                        lambda state: SF_CarRoom(state, self))
+        connect_regions(self, AERoom.W8L2Lava.value, AERoom.Coin62.value,
+                        lambda state: SF_MechRoom(state, self))
 
         # 8-3
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Water.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Outside.value, AERoom.W8L3Lobby.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Tank.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Fan.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L3Outside.value, AERoom.W8L3Fredo.value,
-                        lambda state: HasPunch(state, player))
-        connect_regions(world, player, AERoom.W8L3Water.value, AERoom.W8L3Charlee.value,
-                        lambda state: TVT_HitButton(state, player) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W8L3Water.value, AERoom.W8L3Mach3.value,
-                        lambda state: TVT_HitButton(state, player))
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Tortuss.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Manic.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Ruptdis.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Eighty7.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Danio.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Roosta.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Tellis.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Whack.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Frostee.value,
-                        lambda state: TVT_TankRoom(state, player))
+        connect_regions(self, AERoom.W8L3Water.value, AERoom.Coin64.value,
+                        lambda state: HasFlyer(state, self))
+        connect_regions(self, AERoom.W8L3Tank.value, AERoom.Coin66.value,
+                        lambda state: TVT_TankRoom(state, self))
 
         # 9-1
-        connect_regions(world, player, AEWorld.W9.value, AERoom.W9L1Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Haunted.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.W9L1Coffin.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Natalie.value,
-                        lambda state: MM_Natalie(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Professor.value,
-                        lambda state: MM_Professor(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Jake.value,
-                        lambda state: MM_Jake(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Western.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Crater.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.W9L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Castle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Climb1.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Climb2.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Head.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Side.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Boss.value,
-                        lambda state: MM_FinalBoss(state, player))
-
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Goopo.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.W9L1Porto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Slam.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Junk.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Crib.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Nak.value,
-                        lambda state: HasSling(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Cloy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Shaw.value,
-                        lambda state: HasSling(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Flea.value,
-                        lambda state: HasSling(state, player))
-        connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.W9L1Schafette.value,
-                        lambda state: MM_SHA(state, player) and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Donovan.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Laura.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Uribe.value,
-                        lambda state: MM_UFODoor(state, player) and HasPunch(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Gordo.value,
-                        lambda state: MM_UFODoor(state, player) and HasRC(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Raeski.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Poopie.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Teacup.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Shine.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.W9L1Wrench.value,
-                        lambda state: MM_SpaceMonkeys(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.W9L1Bronson.value,
-                        lambda state: MM_SpaceMonkeys(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Bungee.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Carro.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Carlito.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Side.value, AERoom.W9L1BG.value,
-                        lambda state: MM_SHA(state, player) and HasSling(state, player) and HasFlyer(state, player))
-
-        world.completion_condition[player] = lambda state: state.has("Victory", player, 1)
-
-        if coins:
-            # Coins
-            # 1-1
-            connect_regions(world, player, AERoom.W1L1Main.value, AERoom.Coin1.value, lambda state: NoRequirement())
-            # 1-2
-            connect_regions(world, player, AERoom.W1L2Main.value, AERoom.Coin2.value,
-                            lambda state: CanDive(state, player))
-            # 1-3
-            connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.Coin3.value, lambda state: NoRequirement())
-            # 2-1
-            connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.Coin6.value,
-                            lambda state: HasMobility(state, player))
-            connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.Coin7.value,
-                            lambda state: TJ_Mushroom(state, player))
-            connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.Coin8.value,
-                            lambda state: (TJ_FishEntry(state, player)))
-            connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.Coin9.value,
-                            lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                    (TJ_UFOEntry(state, player)) and (TJ_UFOCliff(state, player))))
-            # 2-2
-            connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
-                            lambda state: HasRC(state, player) or HasPunch(state, player))
-            connect_regions(world, player, AERoom.W2L2Water.value, AERoom.Coin14.value,
-                            lambda state: (CanDive(state, player)) and (
-                                    (CanHitOnce(state, player)) or (HasFlyer(state, player))))
-            # 2-3
-            connect_regions(world, player, AERoom.W2L3Main.value, AERoom.Coin17.value,
-                            lambda state: (CR_Inside(state, player)) and (
-                                    (CanHitMultiple(state, player)) and (CanSwim(state, player))) or (
-                                              HasMobility(state, player)))
-            # 3-1
-            connect_regions(world, player, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, player))
-
-            # 4-1
-            connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.Coin21.value,
-                            lambda state: NoRequirement())
-
-            # 4-2
-            connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.Coin23.value,
-                            lambda state: CanDive(state, player))
-
-            # 4-3
-            connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.Coin24.value,
-                            lambda state: CanSwim(state, player) or CanHitOnce(state, player))
-            connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.Coin25.value,
-                            lambda state: CanDive(state, player) and CanHitOnce(state, player))
-            connect_regions(world, player, AERoom.W4L3Slide.value, AERoom.Coin28.value,
-                            lambda state: (CanSwim(state, player)) and (
-                                    ((CanHitOnce(state, player))) or (HasPunch(state, player))))
-            #Punch or Net, if Net is shuffled.
-
-            # 5-1
-            connect_regions(world, player, AERoom.W5L1Main.value, AERoom.Coin29.value,
-                            lambda state: NoRequirement())
-
-            # 5-2
-            connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.Coin30.value,
-                            lambda state: HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W5L2Water.value, AERoom.Coin31.value,
-                            lambda state: HasFlyer(state, player) and CanDive(state, player))
-            connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.Coin32.value,
-                            lambda state: HasFlyer(state, player))
-
-            # 5-3
-            connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.Coin34.value,
-                            lambda state: HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.Coin35.value,
-                            lambda state: CanHitMultiple(state, player))
-
-            # 6-1
-            connect_regions(world, player, AEWorld.W6.value, AERoom.Coin36.value, lambda state: HasFlyer(state, player))
-
-            # 7-1
-            connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.Coin37.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.Coin38.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L1Well.value, AERoom.Coin39.value,
-                            lambda state: HasFlyer(state, player))
-
-            # 7-2
-            connect_regions(world, player, AERoom.W7L2First.value, AERoom.Coin40.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.Coin41.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.Coin43.value,
-                            lambda state: HasFlyer(state, player))
-
-            # 7-3
-            connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.Coin45.value,
-                            lambda state: HasClub(state, player) or HasFlyer(state, player) or HasPunch(state, player))
-            connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.Coin46.value,
-                            lambda state: CC_5Monkeys(state, player))
-            connect_regions(world, player, AERoom.W7L3Button.value, AERoom.Coin49.value,
-                            lambda state: CC_ButtonRoom(state, player))
-            connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
-                            lambda state: CC_5Monkeys(state, player) or CC_WaterRoom(state, player))
-
-            # 8-1
-            connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.Coin53.value,
-                            lambda state: CP_FrontBarrels(state, player) and CanDive(state, player)
-                            and HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
-                            lambda state: CP_FrontSewer(state, player) and HasRC(state, player))
-            connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
-                            lambda state: CP_FrontBarrels(state, player) and HasFlyer(state, player))
-
-            # 8-2
-            connect_regions(world, player, AERoom.W8L2RC.value, AERoom.Coin58.value,
-                            lambda state: SF_CarRoom(state, player))
-            connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.Coin62.value,
-                            lambda state: SF_MechRoom(state, player))
-
-            # 8-3
-            connect_regions(world, player, AERoom.W8L3Water.value, AERoom.Coin64.value,
-                            lambda state: HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.Coin66.value,
-                            lambda state: TVT_TankRoom(state, player))
-
-            # 9-1
-            connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.Coin73.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.Coin74.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.Coin75.value,
-                            lambda state: HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W9L1Western.value, AERoom.Coin77.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.Coin78.value,
-                            lambda state: MM_SHA(state, player) and HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.Coin79.value,
-                            lambda state: MM_SHA(state, player))
-            connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.Coin80.value,
-                            lambda state: MM_UFODoor(state, player))
-            connect_regions(world, player, AERoom.W9L1Head.value, AERoom.Coin84.value,
-                            lambda state: MM_DoubleDoor(state, player))
-            connect_regions(world, player, AERoom.W9L1Side.value, AERoom.Coin85.value,
-                            lambda state: MM_SHA(state, player) and HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.Coin82.value,
-                            lambda state: MM_SpaceMonkeys(state, player))
+        connect_regions(self, AERoom.W9L1Entry.value, AERoom.Coin73.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Entry.value, AERoom.Coin74.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Haunted.value, AERoom.Coin75.value,
+                        lambda state: HasFlyer(state, self))
+        connect_regions(self, AERoom.W9L1Western.value, AERoom.Coin77.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Crater.value, AERoom.Coin78.value,
+                        lambda state: MM_SHA(state, self) and HasFlyer(state, self))
+        connect_regions(self, AERoom.W9L1Outside.value, AERoom.Coin79.value,
+                        lambda state: MM_SHA(state, self))
+        connect_regions(self, AERoom.W9L1Castle.value, AERoom.Coin80.value,
+                        lambda state: MM_UFODoor(state, self))
+        connect_regions(self, AERoom.W9L1Head.value, AERoom.Coin84.value,
+                        lambda state: MM_DoubleDoor(state, self))
+        connect_regions(self, AERoom.W9L1Side.value, AERoom.Coin85.value,
+                        lambda state: MM_SHA(state, self) and HasFlyer(state, self))
+        connect_regions(self, AERoom.W9L1Climb2.value, AERoom.Coin82.value,
+                        lambda state: MM_SpaceMonkeys(state, self))
 
 
-def Keys(state, player, count):
-    return state.has(AEItem.Key.value, player, count)
+def Keys(state, world, count):
+    return state.has(AEItem.Key.value, world.player, count)
 
 
 def NoRequirement():
     return True
 
 
-def CanHitOnce(state, player):
-    return HasClub(state, player) or HasSling(state, player) or HasPunch(state, player)
+def CanHitOnce(state, world):
+    return HasClub(state, world) or HasSling(state, world) or HasPunch(state, world)
 
 
-def CanHitMultiple(state, player):
-    return HasClub(state, player) or HasPunch(state, player)
+def CanHitMultiple(state, world):
+    return HasClub(state, world) or HasPunch(state, world)
 
 
-def HasMobility(state, player):
-    return HasFlyer(state, player)
+def HasMobility(state, world):
+    return HasFlyer(state, world)
 
 
-def RCMonkey(state, player):
-    return HasRC(state, player)
+def RCMonkey(state, world):
+    return HasRC(state, world)
 
 
-def CanSwim(state, player):
-    return HasWaterNet(state, player)
+def CanSwim(state, world):
+    return HasWaterNet(state, world)
 
 
-def CanDive(state, player):
-    return HasWaterNet(state, player)
+def CanDive(state, world):
+    return HasWaterNet(state, world)
 
 
-def CanWaterCatch(state, player):
-    return HasWaterNet(state, player)
+def CanWaterCatch(state, world):
+    return HasWaterNet(state, world)
 
 
-def SuperFlyer(state, player):
-    return False
-    
-
-def TJ_UFOEntry(state, player):
-    return CanDive(state, player)
-
-
-def TJ_UFOCliff(state, player):
-    return HasFlyer(state, player)
-
-
-def TJ_FishEntry(state, player):
-    return CanSwim(state, player)
-
-
-def TJ_Mushroom(state, player):
-    return HasMobility(state, player) and CanHitMultiple(state, player)
-
-
-def CR_Inside(state, player):
-    return HasSling(state, player) or HasPunch(state, player)
-
-
-def DI_SecondHalf(state, player):
-    return CanHitOnce(state, player) and CanDive(state, player)
-
-
-def DI_Boulders(state, player):
-    return HasHoop(state, player) or HasRC(state, player)
-
-
-def WSW_ThirdRoom(state, player):
-    return HasSling(state, player) or HasFlyer(state, player)
-
-
-def WSW_FourthRoom(state, player):
-    return CanHitMultiple(state, player) or HasFlyer(state, player)
-
-
-def CC_5Monkeys(state, player):
-    return HasClub(state, player) or HasFlyer(state, player) or HasPunch(state, player)
-
-
-def CC_WaterRoom(state, player):
-    return CanHitMultiple(state, player) or (CanDive(state, player) and HasPunch(state, player))
-
-
-def CC_ButtonRoom(state, player):
-    return CC_WaterRoom(state, player) and CanSwim(state, player)
-
-
-def CP_FrontSewer(state, player):
-    return HasRC(state, player)
-
-
-def CP_FrontBarrels(state, player):
-    return CP_FrontSewer(state, player) and (CanSwim(state, player) or HasMobility(state, player))
-
-
-def CP_BackSewer(state, player):
+def SuperFlyer(state, world):
     return False
 
 
-def SF_CarRoom(state, player):
-    return HasRC(state, player) or HasPunch(state, player)
+def TJ_UFOEntry(state, world):
+    return CanDive(state, world)
 
 
-def SF_MechRoom(state, player):
-    return HasClub(state, player) and SF_CarRoom(state, player)
+def TJ_UFOCliff(state, world):
+    return HasFlyer(state, world)
 
 
-def TVT_HitButton(state, player):
-    return HasFlyer(state, player) and CanHitOnce(state, player)
+def TJ_FishEntry(state, world):
+    return CanSwim(state, world)
 
 
-def TVT_TankRoom(state, player):
-    return TVT_HitButton(state, player)
+def TJ_Mushroom(state, world):
+    return HasMobility(state, world) and CanHitMultiple(state, world)
 
 
-def MM_Natalie(state, player):
-    return CanHitMultiple(state, player)
+def CR_Inside(state, world):
+    return HasSling(state, world) or HasPunch(state, world)
 
 
-def MM_Professor(state, player):
-    return HasFlyer(state, player) and CanHitMultiple(state, player)
+def DI_SecondHalf(state, world):
+    return CanHitOnce(state, world) and CanDive(state, world)
 
 
-def Jake_Open(state, player):
-    return MM_Natalie(state, player) and MM_Professor(state, player)
+def DI_Boulders(state, world):
+    return HasHoop(state, world) or HasRC(state, world)
 
 
-def MM_Jake(state, player):
-    return (HasClub(state, player) or HasPunch(state, player)) and Jake_Open(state, player)
+def WSW_ThirdRoom(state, world):
+    return HasSling(state, world) or HasFlyer(state, world)
 
 
-def MM_SHA(state, player):
-    return MM_Natalie(state, player) and MM_Professor(state, player) and MM_Jake(state, player)
+def WSW_FourthRoom(state, world):
+    return CanHitMultiple(state, world) or HasFlyer(state, world)
 
 
-def MM_UFODoor(state, player):
-    return MM_SHA(state, player) and HasSling(state, player)
+def CC_5Monkeys(state, world):
+    return HasClub(state, world) or HasFlyer(state, world) or HasPunch(state, world)
 
 
-def MM_DoubleDoor(state, player):
-    return MM_UFODoor(state, player) and HasHoop(state, player) and HasRC(state, player) \
-        and CanHitMultiple(state, player)
+def CC_WaterRoom(state, world):
+    return CanHitMultiple(state, world) or (CanDive(state, world) and HasPunch(state, world))
 
 
-def MM_SpaceMonkeys(state, player):
-    return MM_DoubleDoor(state, player) and HasFlyer(state, player)
+def CC_ButtonRoom(state, world):
+    return CC_WaterRoom(state, world) and CanSwim(state, world)
 
 
-def MM_FinalBoss(state, player):
-    return MM_DoubleDoor(state, player) and HasSling(state, player) and HasFlyer(state, player)
+def CP_FrontSewer(state, world):
+    return HasRC(state, world)
 
 
-def HasClub(state, player):
-    return state.has(AEItem.Club.value, player, 1)
+def CP_FrontBarrels(state, world):
+    return CP_FrontSewer(state, world) and (CanSwim(state, world) or HasMobility(state, world))
 
 
-def HasNet(state, player):
-    return state.has(AEItem.Net.value, player, 1)
+def CP_BackSewer(state, world):
+    return False
 
 
-def HasRadar(state, player):
-    return state.has(AEItem.Radar.value, player, 1)
+def SF_CarRoom(state, world):
+    return HasRC(state, world) or HasPunch(state, world)
 
 
-def HasSling(state, player):
-    return state.has(AEItem.Sling.value, player, 1)
+def SF_MechRoom(state, world):
+    return HasClub(state, world) and SF_CarRoom(state, world)
 
 
-def HasHoop(state, player):
-    return state.has(AEItem.Hoop.value, player, 1)
+def TVT_HitButton(state, world):
+    return HasFlyer(state, world) and CanHitOnce(state, world)
 
 
-def HasFlyer(state, player):
-    return state.has(AEItem.Flyer.value, player, 1)
+def TVT_TankRoom(state, world):
+    return TVT_HitButton(state, world)
 
 
-def HasRC(state, player):
-    return state.has(AEItem.Car.value, player, 1)
+def MM_Natalie(state, world):
+    return CanHitMultiple(state, world)
 
 
-def HasPunch(state, player):
-    return state.has(AEItem.Punch.value, player, 1)
+def MM_Professor(state, world):
+    return HasFlyer(state, world) and CanHitMultiple(state, world)
 
 
-def HasWaterNet(state, player):
-    return state.has(AEItem.WaterNet.value, player, 1)
+def Jake_Open(state, world):
+    return MM_Natalie(state, world) and MM_Professor(state, world)
+
+
+def MM_Jake(state, world):
+    return (HasClub(state, world) or HasPunch(state, world)) and Jake_Open(state, world)
+
+
+def MM_SHA(state, world):
+    return MM_Natalie(state, world) and MM_Professor(state, world) and MM_Jake(state, world)
+
+
+def MM_UFODoor(state, world):
+    return MM_SHA(state, world) and HasSling(state, world)
+
+
+def MM_DoubleDoor(state, world):
+    return MM_UFODoor(state, world) and HasHoop(state, world) and HasRC(state, world) \
+        and CanHitMultiple(state, world)
+
+
+def MM_SpaceMonkeys(state, world):
+    return MM_DoubleDoor(state, world) and HasFlyer(state, world)
+
+
+def MM_FinalBoss(state, world):
+    return MM_DoubleDoor(state, world) and HasSling(state, world) and HasFlyer(state, world)
+
+
+def HasClub(state, world):
+    return state.has(AEItem.Club.value, world.player, 1)
+
+
+def HasNet(state, world):
+    return state.has(AEItem.Net.value, world.player, 1)
+
+
+def HasRadar(state, world):
+    return state.has(AEItem.Radar.value, world.player, 1)
+
+
+def HasSling(state, world):
+    return state.has(AEItem.Sling.value, world.player, 1)
+
+
+def HasHoop(state, world):
+    return state.has(AEItem.Hoop.value, world.player, 1)
+
+
+def HasFlyer(state, world):
+    return state.has(AEItem.Flyer.value, world.player, 1)
+
+
+def HasRC(state, world):
+    return state.has(AEItem.Car.value, world.player, 1)
+
+
+def HasPunch(state, world):
+    return state.has(AEItem.Punch.value, world.player, 1)
+
+
+def HasWaterNet(state, world):
+    return state.has(AEItem.WaterNet.value, world.player, 1)

--- a/worlds/apeescape/RulesGlitchless.py
+++ b/worlds/apeescape/RulesGlitchless.py
@@ -18,9 +18,7 @@ def set_glitchless_rules(self):
 
     if self.options.goal == "second":
         connect_regions(self, "Menu", AERoom.W9L2Boss.value,
-                        lambda state: Keys(state, self, 6) and HasSling(state, self)
-                                      and HasHoop(state, self) and HasFlyer(state, self)
-                                      and CanHitMultiple(state, self) and HasRC(state, self))
+                        lambda state: Keys(state, self, 6) and HasSling(state, self) and HasHoop(state, self) and HasFlyer(state, self) and CanHitMultiple(state, self) and HasRC(state, self))
 
     # 1-1
     connect_regions(self, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
@@ -28,8 +26,7 @@ def set_glitchless_rules(self):
     connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Noonan.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Jorjy.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Nati.value, lambda state: NoRequirement())
-    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value,
-                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value, lambda state: HasFlyer(state, self))
 
     # 1-2
     connect_regions(self, AEWorld.W1.value, AERoom.W1L2Main.value, lambda state: True)
@@ -91,16 +88,11 @@ def set_glitchless_rules(self):
                     lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
                             TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
     connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
-                    lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self)
-                                                                  and TJ_UFOCliff(state, self)))
-                                   and CanHitMultiple(state, self)))
+                    lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))) and CanHitMultiple(state, self)))
     connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value,
-                    lambda state: (TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self))
-                                   and CanHitMultiple(state, self)) and HasSling(state, self))
+                    lambda state: (TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)) and HasSling(state, self))
     connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value,
-                    lambda state: ((TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))
-                                   or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self))
-                                  and HasSling(state, self))
+                    lambda state: ((TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)) and HasSling(state, self))
 
     # 2-2
     connect_regions(self, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
@@ -124,13 +116,11 @@ def set_glitchless_rules(self):
     connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
                     lambda state: HasSling(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
-                    lambda state: CanSwim(state, self) and (HasSling(state, self) or HasHoop(state, self))
-                                  and (CanHitOnce(state, self) or HasFlyer(state, self)))
+                    lambda state: CanSwim(state, self) and (HasSling(state, self) or HasHoop(state, self)) and (CanHitOnce(state, self) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
                     lambda state: CanHitMultiple(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
-                    lambda state: CanSwim(state, self) and (HasSling(state, self) or HasHoop(state, self))
-                                  and (CanHitOnce(state, self) or HasFlyer(state, self)))
+                    lambda state: CanSwim(state, self) and (HasSling(state, self) or HasHoop(state, self)) and (CanHitOnce(state, self) or HasFlyer(state, self)))
 
     # 2-3
     connect_regions(self, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
@@ -142,13 +132,11 @@ def set_glitchless_rules(self):
                     lambda state: HasSling(state, self) or HasFlyer(state, self))
     connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Freeto.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W2L3Side.value, AERoom.W2L3Troopa.value,
-                    lambda state: (HasSling(state, self) or (HasFlyer(state, self)
-                                                             and CanHitOnce(state, self))))
+                    lambda state: (HasSling(state, self) or (HasFlyer(state, self) and CanHitOnce(state, self))))
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
                     lambda state: CR_Inside(state, self))
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
-                    lambda state: CR_Inside(state, self) and CanSwim(state, self) and (
-                            HasFlyer(state, self) or CanHitMultiple(state, self)))
+                    lambda state: CR_Inside(state, self) and CanSwim(state, self) and (HasFlyer(state, self) or CanHitMultiple(state, self)))
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
                     lambda state: CR_Inside(state, self) and (CanHitMultiple(state, self) or (
                             CanSwim(state, self) and HasMobility(state, self))))
@@ -185,13 +173,11 @@ def set_glitchless_rules(self):
     connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Chip.value,
                     lambda state: CanSwim(state, self) and CanWaterCatch(state, self))
     connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
-                    lambda state: (HasHoop(state, self) and CanHitMultiple(state, self)
-                                   and CanSwim(state, self)) or HasMobility(state, self))
+                    lambda state: (HasHoop(state, self) and CanHitMultiple(state, self) and CanSwim(state, self)) or HasMobility(state, self))
     connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
                     lambda state: CanDive(state, self))
     connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value,
-                    lambda state: (HasHoop(state, self) and CanHitMultiple(state, self) and CanSwim(state, self))
-                                  or HasMobility(state, self))
+                    lambda state: (HasHoop(state, self) and CanHitMultiple(state, self) and CanSwim(state, self)) or HasMobility(state, self))
     connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
                     lambda state: CanSwim(state, self))
     connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2BongBong.value,
@@ -300,8 +286,7 @@ def set_glitchless_rules(self):
 
     connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Taku.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Rocka.value, lambda state: NoRequirement())
-    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value,
-                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Wog.value,
                     lambda state: HasSling(state, self))
     connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Mayi.value, lambda state: NoRequirement())
@@ -335,11 +320,9 @@ def set_glitchless_rules(self):
     connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
                     lambda state: WSW_ThirdRoom(state, self) and RCMonkey(state, self))
     connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
-                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self)
-                                  and HasSling(state, self))
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and HasSling(state, self))
     connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
-                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
-                            HasSling(state, self) or HasFlyer(state, self)))
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
 
     # 7-3
     connect_regions(self, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
@@ -396,8 +379,7 @@ def set_glitchless_rules(self):
                     lambda state: RCMonkey(state, self))
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
-                    lambda state: CP_FrontBarrels(state, self) and CanDive(state, self)
-                                  and HasFlyer(state, self))
+                    lambda state: CP_FrontBarrels(state, self) and CanDive(state, self) and HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
                     lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
@@ -409,18 +391,15 @@ def set_glitchless_rules(self):
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
                     lambda state: CP_FrontBarrels(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
-                    lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self)
-                                  and CanDive(state, self))
+                    lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self) and CanDive(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
                     lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
                     lambda state: CP_FrontBarrels(state, self) and HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
-                    lambda state: CP_FrontBarrels(state, self) and CanDive(state, self)
-                                  and HasFlyer(state, self))
+                    lambda state: CP_FrontBarrels(state, self) and CanDive(state, self) and HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
-                    lambda state: CP_FrontBarrels(state, self) and CanSwim(state, self)
-                                  and HasFlyer(state, self))
+                    lambda state: CP_FrontBarrels(state, self) and CanSwim(state, self) and HasFlyer(state, self))
 
     # 8-2
     connect_regions(self, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
@@ -567,21 +546,17 @@ def set_glitchless_rules(self):
         connect_regions(self, AERoom.W2L1Fish.value, AERoom.Coin8.value,
                         lambda state: (TJ_FishEntry(state, self)))
         connect_regions(self, AERoom.W2L1Tent.value, AERoom.Coin9.value,
-                        lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
-                                (TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
+                        lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or ((TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
         # 2-2
         connect_regions(self, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
         connect_regions(self, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
         connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
                         lambda state: HasRC(state, self) or HasPunch(state, self))
         connect_regions(self, AERoom.W2L2Water.value, AERoom.Coin14.value,
-                        lambda state: (CanDive(state, self)) and (
-                                (CanHitOnce(state, self)) or (HasFlyer(state, self))))
+                        lambda state: (CanDive(state, self)) and ((CanHitOnce(state, self)) or (HasFlyer(state, self))))
         # 2-3
         connect_regions(self, AERoom.W2L3Main.value, AERoom.Coin17.value,
-                        lambda state: (CR_Inside(state, self)) and (
-                                (CanHitMultiple(state, self)) and (CanSwim(state, self))) or (
-                                          HasMobility(state, self)))
+                        lambda state: (CR_Inside(state, self)) and ((CanHitMultiple(state, self)) and (CanSwim(state, self))) or (HasMobility(state, self)))
         # 3-1
         connect_regions(self, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, self))
 
@@ -599,8 +574,7 @@ def set_glitchless_rules(self):
         connect_regions(self, AERoom.W4L3Stomach.value, AERoom.Coin25.value,
                         lambda state: CanDive(state, self) and CanHitOnce(state, self))
         connect_regions(self, AERoom.W4L3Slide.value, AERoom.Coin28.value,
-                        lambda state: (CanSwim(state, self)) and (
-                                (CanHitOnce(state, self)) or (HasPunch(state, self))))
+                        lambda state: (CanSwim(state, self)) and ((CanHitOnce(state, self)) or (HasPunch(state, self))))
         # Punch or Net, if Net is shuffled.
 
         # 5-1
@@ -652,8 +626,7 @@ def set_glitchless_rules(self):
 
         # 8-1
         connect_regions(self, AERoom.W8L1Outside.value, AERoom.Coin53.value,
-                        lambda state: CP_FrontBarrels(state, self) and CanDive(state, self)
-                                      and HasFlyer(state, self))
+                        lambda state: CP_FrontBarrels(state, self) and CanDive(state, self) and HasFlyer(state, self))
         connect_regions(self, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
                         lambda state: CP_FrontSewer(state, self) and HasRC(state, self))
         connect_regions(self, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
@@ -835,8 +808,7 @@ def MM_UFODoor(state, world):
 
 
 def MM_DoubleDoor(state, world):
-    return MM_UFODoor(state, world) and HasHoop(state, world) and HasRC(state, world) \
-        and CanHitMultiple(state, world)
+    return MM_UFODoor(state, world) and HasHoop(state, world) and HasRC(state, world) and CanHitMultiple(state, world)
 
 
 def MM_SpaceMonkeys(state, world):

--- a/worlds/apeescape/RulesIJ.py
+++ b/worlds/apeescape/RulesIJ.py
@@ -18,9 +18,7 @@ def set_ij_rules(self):
 
     if self.options.goal == "second":
         connect_regions(self, "Menu", AERoom.W9L2Boss.value,
-                        lambda state: Keys(state, self, 6) and HasSling(state, self)
-                        and HasHoop(state, self) and HasFlyer(state, self) and CanHitMultiple(state, self)
-                        and HasRC(state, self))
+                        lambda state: Keys(state, self, 6) and HasSling(state, self) and HasHoop(state, self) and HasFlyer(state, self) and CanHitMultiple(state, self) and HasRC(state, self))
 
     # 1-1
     connect_regions(self, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
@@ -74,8 +72,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
                     lambda state: TJ_Mushroom(state, self))
     connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
-                    lambda state: TJ_FishEntry(state, self) and (
-                            HasSling(state, self) or HasFlyer(state, self)))
+                    lambda state: TJ_FishEntry(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
                     lambda state: TJ_FishEntry(state, self))
     connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
@@ -89,12 +86,10 @@ def set_ij_rules(self):
                             TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
     connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
                     lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))) and CanHitMultiple(state, self)))
-    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value, lambda state: (
-            TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)))
-    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value, lambda state: (
-            (TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)) or (TJ_FishEntry(state, self))
-            and CanHitMultiple(state, self)) and (HasClub(state, self) or HasSling(state, self)
-                                                    or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value,
+                    lambda state: (TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value,
+                    lambda state: ((TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)) and (HasClub(state, self) or HasSling(state, self) or HasFlyer(state, self)))
 
     # 2-2
     connect_regions(self, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
@@ -116,13 +111,11 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
                     lambda state: HasSling(state, self) or HasPunch(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
-                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
-                    or HasHoop(state, self))
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self) or HasHoop(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
                     lambda state: CanHitMultiple(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
-                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
-                    or HasHoop(state, self))
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self) or HasHoop(state, self))
 
     # 2-3
     connect_regions(self, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
@@ -137,9 +130,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
                     lambda state: CR_Inside(state, self))
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
-                    lambda state: CR_Inside(state, self) and (
-                            (CanSwim(state, self) and CanHitMultiple(state, self)) or HasSling(state, self)
-                            or HasFlyer(state, self)))
+                    lambda state: CR_Inside(state, self) and ((CanSwim(state, self) and CanHitMultiple(state, self)) or HasSling(state, self) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
                     lambda state: CR_Inside(state, self) and (CanHitMultiple(state, self) or (
                             CanSwim(state, self) and HasMobility(state, self))))
@@ -163,8 +154,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Shaka.value,
                     lambda state: NoRequirement())
     connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Puka.value,
-                    lambda state: CanHitMultiple(state, self) or HasHoop(state, self)
-                    or HasFlyer(state, self))
+                    lambda state: CanHitMultiple(state, self) or HasHoop(state, self) or HasFlyer(state, self))
     connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1MaxMahalo.value,
                     lambda state: HasHoop(state, self) or HasSling(state, self))
     connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Moko.value,
@@ -179,8 +169,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
                     lambda state: (HasMobility(state, self)))
     connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
-                    lambda state: CanDive(state, self) or HasSling(state, self) or (
-                            HasHoop(state, self) and HasFlyer(state, self)))
+                    lambda state: CanDive(state, self) or HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self)))
     connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value,
                     lambda state: (HasMobility(state, self)))
     connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
@@ -190,8 +179,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Jux.value,
                     lambda state: CanSwim(state, self) or HasSling(state, self))
     connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Pickles.value,
-                    lambda state: (CanSwim(state, self) and CanHitMultiple(state, self))
-                    or HasSling(state, self))
+                    lambda state: (CanSwim(state, self) and CanHitMultiple(state, self)) or HasSling(state, self))
 
     # 4-3
     connect_regions(self, AEWorld.W4.value, AERoom.W4L3Outside.value, lambda state: True)
@@ -212,11 +200,9 @@ def set_ij_rules(self):
                     lambda state: CanHitOnce(state, self) and (
                             CanSwim(state, self) or HasSling(state, self) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Howeerd.value,
-                    lambda state: DI_SecondHalf(state, self) and (
-                            HasSling(state, self) or HasFlyer(state, self)))
+                    lambda state: DI_SecondHalf(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Robbin.value,
-                    lambda state: DI_SecondHalf(state, self) and (
-                            HasSling(state, self) or HasFlyer(state, self)))
+                    lambda state: DI_SecondHalf(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Jakkee.value,
                     lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
     connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Frederic.value,
@@ -233,8 +219,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
                     lambda state: CanHitOnce(state, self))
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
-                    lambda state: HasSling(state, self) or HasPunch(state, self) or (
-                            HasClub(state, self) and HasFlyer(state, self)))
+                    lambda state: HasSling(state, self) or HasPunch(state, self) or (HasClub(state, self) and HasFlyer(state, self)))
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value, lambda state: NoRequirement())
@@ -247,8 +232,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Storm.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Qube.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Ranix.value,
-                    lambda state: CanSwim(state, self) or HasSling(state, self) or (
-                            HasHoop(state, self) and HasFlyer(state, self)))
+                    lambda state: CanSwim(state, self) or HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self)))
     connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sharpe.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sticky.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Droog.value,
@@ -299,8 +283,7 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
                     lambda state: HasSling(state, self) or HasFlyer(state, self))
     connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
-                    lambda state: HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self))
-                                  or SuperFlyer(state, self))
+                    lambda state: HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self)) or SuperFlyer(state, self))
     connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
 
@@ -323,11 +306,9 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
                     lambda state: WSW_ThirdRoom(state, self) and RCMonkey(state, self))
     connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
-                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
-                            HasSling(state, self) or HasHoop(state, self)))
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (HasSling(state, self) or HasHoop(state, self)))
     connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
-                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
-                            HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
 
     # 7-3
     connect_regions(self, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
@@ -383,40 +364,27 @@ def set_ij_rules(self):
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
-                    lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
-                    or HasSling(state, self) or HasFlyer(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self)) or HasSling(state, self) or HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
                     lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
-                    lambda state: (CP_FrontSewer(state, self) or CP_BackSewer(state, self))
-                    and HasRC(state, self))
+                    lambda state: (CP_FrontSewer(state, self) or CP_BackSewer(state, self)) and HasRC(state, self))
     connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
-                    lambda state: (CP_FrontSewer(state, self) and HasRC(state, self))
-                    or CP_BackSewer(state, self))
+                    lambda state: (CP_FrontSewer(state, self) and HasRC(state, self)) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
-                    lambda state: ((CP_FrontSewer(state, self) or CP_BackSewer(state, self))
-                                   and HasRC(state, self)) or HasSling(state, self) or HasFlyer(state, self))
+                    lambda state: ((CP_FrontSewer(state, self) or CP_BackSewer(state, self)) and HasRC(state, self)) or HasSling(state, self) or HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
                     lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
-                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
-                    and CanDive(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self)) and CanDive(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
                     lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
-                    lambda state: (CP_FrontBarrels(state, self) and (CanSwim(state, self)
-                                                                       or HasSling(state, self)
-                                                                       or HasFlyer(state, self)))
-                    or CP_BackSewer(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) and (CanSwim(state, self) or HasSling(state, self) or HasFlyer(state, self))) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
-                    lambda state: ((CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
-                                   and CanDive(state, self)) or (HasSling(state, self)
-                                                                   and HasRC(state, self)))
+                    lambda state: ((CP_FrontBarrels(state, self) or CP_BackSewer(state, self)) and CanDive(state, self)) or (HasSling(state, self) and HasRC(state, self)))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
-                    lambda state: (CP_FrontBarrels(state, self)
-                                   and (HasHoop(state, self) or CanSwim(state, self))
-                                   and HasFlyer(state, self)) or CP_BackSewer(state, self)
-                    or HasSling(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) and (HasHoop(state, self) or CanSwim(state, self)) and HasFlyer(state, self)) or CP_BackSewer(state, self) or HasSling(state, self))
 
     # 8-2
     connect_regions(self, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
@@ -563,20 +531,17 @@ def set_ij_rules(self):
         connect_regions(self, AERoom.W2L1Fish.value, AERoom.Coin8.value,
                         lambda state: (TJ_FishEntry(state, self)))
         connect_regions(self, AERoom.W2L1Tent.value, AERoom.Coin9.value,
-                        lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
-                                (TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
+                        lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or ((TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
         # 2-2
         connect_regions(self, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
         connect_regions(self, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
         connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
-                        lambda state: (HasHoop(state, self) and HasFlyer(state, self)) or
-                                      HasSling(state, self) or HasRC(state, self) or HasPunch(state, self))
+                        lambda state: (HasHoop(state, self) and HasFlyer(state, self)) or HasSling(state, self) or HasRC(state, self) or HasPunch(state, self))
         connect_regions(self, AERoom.W2L2Water.value, AERoom.Coin14.value,
                         lambda state: CanDive(state, self) and CanHitOnce(state, self))
         # 2-3
         connect_regions(self, AERoom.W2L3Main.value, AERoom.Coin17.value,
-                        lambda state: CR_Inside(state, self)
-                                      and (CanSwim(state, self) or HasMobility(state, self)))
+                        lambda state: CR_Inside(state, self) and (CanSwim(state, self) or HasMobility(state, self)))
         # 3-1
         connect_regions(self, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, self))
 
@@ -636,29 +601,21 @@ def set_ij_rules(self):
 
         # 7-3
         connect_regions(self, AERoom.W7L3Outside.value, AERoom.Coin45.value,
-                        lambda state: HasClub(state, self) or HasSling(state, self) or HasHoop(state, self)
-                                      or HasFlyer(state, self) or HasPunch(state, self))
+                        lambda state: HasClub(state, self) or HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self) or HasPunch(state, self))
         connect_regions(self, AERoom.W7L3Castle.value, AERoom.Coin46.value,
                         lambda state: CC_5Monkeys(state, self) or HasSling(state, self))
         connect_regions(self, AERoom.W7L3Button.value, AERoom.Coin49.value,
                         lambda state: CC_ButtonRoom(state, self))
         connect_regions(self, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
-                        lambda state: CC_5Monkeys(state, self) or CC_WaterRoom(state, self) or
-                                      HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self)))
+                        lambda state: CC_5Monkeys(state, self) or CC_WaterRoom(state, self) or HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self)))
 
         # 8-1
         connect_regions(self, AERoom.W8L1Outside.value, AERoom.Coin53.value,
-                        lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
-                                      or HasSling(state, self) or HasFlyer(state, self))
+                        lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self)) or HasSling(state, self) or HasFlyer(state, self))
         connect_regions(self, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
-                        lambda state: (CP_FrontSewer(state, self)
-                                       and (HasRC(state, self) or HasSling(state, self)
-                                            or SuperFlyer(state, self))) or (CP_BackSewer(state, self)
-                                                                               and HasRC(state, self)
-                                                                               or HasSling(state, self)))
+                        lambda state: (CP_FrontSewer(state, self) and (HasRC(state, self) or HasSling(state, self) or SuperFlyer(state, self))) or (CP_BackSewer(state, self) and HasRC(state, self) or HasSling(state, self)))
         connect_regions(self, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
-                        lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
-                                      and (HasSling(state, self) or HasFlyer(state, self)))
+                        lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self)) and (HasSling(state, self) or HasFlyer(state, self)))
 
         # 8-2
         connect_regions(self, AERoom.W8L2RC.value, AERoom.Coin58.value,

--- a/worlds/apeescape/RulesIJ.py
+++ b/worlds/apeescape/RulesIJ.py
@@ -704,7 +704,7 @@ def NoRequirement():
 
 
 def CanHitOnce(state, world):
-    return (HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasRC(state, world) or HasPunch(state, world))
+    return HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasRC(state, world) or HasPunch(state, world)
 
 
 def CanHitMultiple(state, world):
@@ -772,11 +772,11 @@ def WSW_FourthRoom(state, world):
 
 
 def CC_5Monkeys(state, world):
-    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasPunch(state, world))
+    return HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasPunch(state, world)
 
 
 def CC_WaterRoom(state, world):
-    return ((CanHitMultiple(state, world) and HasNet(state, world)) or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world))) or HasFlyer(state, world) or HasHoop(state, world) or HasSling(state, world) or SuperFlyer(state, world))
+    return (CanHitMultiple(state, world) and HasNet(state, world)) or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world))) or HasFlyer(state, world) or HasHoop(state, world) or HasSling(state, world) or SuperFlyer(state, world)
 
 
 def CC_ButtonRoom(state, world):
@@ -796,7 +796,7 @@ def CP_BackSewer(state, world):
 
 
 def SF_CarRoom(state, world):
-    return (HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world) or HasPunch(state, world))
+    return HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world) or HasPunch(state, world)
 
 
 def SF_MechRoom(state, world):

--- a/worlds/apeescape/RulesIJ.py
+++ b/worlds/apeescape/RulesIJ.py
@@ -1,888 +1,891 @@
-from worlds.apeescape import location_table
-from worlds.generic.Rules import add_rule, set_rule, forbid_item
-from BaseClasses import LocationProgressType
 from .Regions import connect_regions
-from .Options import SuperFlyerOption
 from .Strings import AEItem, AEWorld, AERoom
 
 
-class IJ():
-    def set_rules(self, world, player: int, coins: bool):
+def set_ij_rules(self):
+    # Worlds
+    connect_regions(self, "Menu", AEWorld.W1.value, lambda state: NoRequirement())
+    connect_regions(self, "Menu", AEWorld.W2.value, lambda state: Keys(state, self, 1))
+    connect_regions(self, "Menu", AEWorld.W3.value,
+                    lambda state: CanSwim(state, self) and Keys(state, self, 2))
+    connect_regions(self, "Menu", AEWorld.W4.value, lambda state: Keys(state, self, 2))
+    connect_regions(self, "Menu", AEWorld.W5.value, lambda state: Keys(state, self, 3))
+    connect_regions(self, "Menu", AEWorld.W6.value,
+                    lambda state: HasFlyer(state, self) and Keys(state, self, 4))
+    connect_regions(self, "Menu", AEWorld.W7.value, lambda state: Keys(state, self, 4))
+    connect_regions(self, "Menu", AEWorld.W8.value, lambda state: Keys(state, self, 5))
+    connect_regions(self, "Menu", AEWorld.W9.value, lambda state: Keys(state, self, 6))
 
-        # Worlds
-        connect_regions(world, player, "Menu", AEWorld.W1.value, lambda state: NoRequirement())
-        connect_regions(world, player, "Menu", AEWorld.W2.value, lambda state: Keys(state, player, 1))
-        connect_regions(world, player, "Menu", AEWorld.W3.value,
-                        lambda state: CanSwim(state, player) and Keys(state, player, 2))
-        connect_regions(world, player, "Menu", AEWorld.W4.value, lambda state: Keys(state, player, 2))
-        connect_regions(world, player, "Menu", AEWorld.W5.value, lambda state: Keys(state, player, 3))
-        connect_regions(world, player, "Menu", AEWorld.W6.value,
-                        lambda state: HasFlyer(state, player) and Keys(state, player, 4))
-        connect_regions(world, player, "Menu", AEWorld.W7.value, lambda state: Keys(state, player, 4))
-        connect_regions(world, player, "Menu", AEWorld.W8.value, lambda state: Keys(state, player, 5))
-        connect_regions(world, player, "Menu", AEWorld.W9.value, lambda state: Keys(state, player, 6))
+    if self.options.goal == "second":
+        connect_regions(self, "Menu", AERoom.W9L2Boss.value,
+                        lambda state: Keys(state, self, 6) and HasSling(state, self)
+                        and HasHoop(state, self) and HasFlyer(state, self) and CanHitMultiple(state, self)
+                        and HasRC(state, self))
 
-        if world.goal[player].value == 0x01:
-            connect_regions(world, player, "Menu", AERoom.W9L2Boss.value,
-                            lambda state: Keys(state, player, 6) and HasSling(state, player)
-                            and HasHoop(state, player) and HasFlyer(state, player) and CanHitMultiple(state, player)
-                            and HasRC(state, player))
+    # 1-1
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
 
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Noonan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Jorjy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Nati.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value, lambda state: NoRequirement())
+
+    # 1-2
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L2Main.value, lambda state: True)
+
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Shay.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2DrMonk.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Grunt.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Ahchoo.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Gornif.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Tyrone.value, lambda state: NoRequirement())
+
+    # 1-3
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L3Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Volcano.value, lambda state: True)
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Triceratops.value,
+                    lambda state: HasSling(state, self))
+
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Scotty.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Coco.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3JThomas.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Moggan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Volcano.value, AERoom.W1L3Barney.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Volcano.value, AERoom.W1L3Mattie.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Triceratops.value, AERoom.W1L3Rocky.value,
+                    lambda state: HasSling(state, self))
+
+    # 2-1
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L1Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Mushroom.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Fish.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Tent.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Boulder.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Marquez.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Livinston.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1George.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Gonzo.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Zanzibar.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
+                    lambda state: TJ_FishEntry(state, self) and (
+                            HasSling(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
+                    lambda state: TJ_FishEntry(state, self))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Stoddy.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Mitong.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
+                    lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))) and CanHitMultiple(state, self)))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value, lambda state: (
+            TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value, lambda state: (
+            (TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)) or (TJ_FishEntry(state, self))
+            and CanHitMultiple(state, self)) and (HasClub(state, self) or HasSling(state, self)
+                                                    or HasFlyer(state, self)))
+
+    # 2-2
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Fan.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Obelisk.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Water.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Kyle.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Stan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Kenny.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Cratman.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Mooshy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Fan.value, AERoom.W2L2Nuzzy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Fan.value, AERoom.W2L2Mav.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Papou.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Trance.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
+                    lambda state: HasSling(state, self) or HasPunch(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
+                    or HasHoop(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
+                    lambda state: CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
+                    or HasHoop(state, self))
+
+    # 2-3
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Side.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Main.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Pillar.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Bazzle.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Freeto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L3Side.value, AERoom.W2L3Troopa.value,
+                    lambda state: (HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
+                    lambda state: CR_Inside(state, self))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
+                    lambda state: CR_Inside(state, self) and (
+                            (CanSwim(state, self) and CanHitMultiple(state, self)) or HasSling(state, self)
+                            or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
+                    lambda state: CR_Inside(state, self) and (CanHitMultiple(state, self) or (
+                            CanSwim(state, self) and HasMobility(state, self))))
+    connect_regions(self, AERoom.W2L3Pillar.value, AERoom.W2L3Pally.value,
+                    lambda state: CR_Inside(state, self))
+    connect_regions(self, AERoom.W2L3Pillar.value, AERoom.W2L3Crash.value,
+                    lambda state: CR_Inside(state, self) and (RCMonkey(state, self) or SuperFlyer(state, self)))
+
+    # 4-1
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L1FirstRoom.value, lambda state: True)
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1SecondRoom.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1CoolBlue.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1Sandy.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1ShellE.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1Gidget.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Shaka.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Puka.value,
+                    lambda state: CanHitMultiple(state, self) or HasHoop(state, self)
+                    or HasFlyer(state, self))
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1MaxMahalo.value,
+                    lambda state: HasHoop(state, self) or HasSling(state, self))
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Moko.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+
+    # 4-2
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L2FirstRoom.value, lambda state: True)
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2SecondRoom.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Chip.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
+                    lambda state: (HasMobility(state, self)))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
+                    lambda state: CanDive(state, self) or HasSling(state, self) or (
+                            HasHoop(state, self) and HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value,
+                    lambda state: (HasMobility(state, self)))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
+                    lambda state: CanSwim(state, self) or HasSling(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2BongBong.value,
+                    lambda state: CanSwim(state, self) or HasSling(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Jux.value,
+                    lambda state: CanSwim(state, self) or HasSling(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Pickles.value,
+                    lambda state: (CanSwim(state, self) and CanHitMultiple(state, self))
+                    or HasSling(state, self))
+
+    # 4-3
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3Stomach.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Slide.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Slide.value, AERoom.W4L3Gallery.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Tentacle.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3TonTon.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3Stuw.value,
+                    lambda state: CanSwim(state, self) or CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Mars.value,
+                    lambda state: HasRC(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Murky.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Horke.value,
+                    lambda state: CanHitOnce(state, self) and (
+                            CanSwim(state, self) or HasSling(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Howeerd.value,
+                    lambda state: DI_SecondHalf(state, self) and (
+                            HasSling(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Robbin.value,
+                    lambda state: DI_SecondHalf(state, self) and (
+                            HasSling(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Jakkee.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Frederic.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Baba.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Tentacle.value, AERoom.W4L3Quirck.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+
+    # 5-1
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L1Main.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Popcicle.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
+                    lambda state: HasSling(state, self) or HasPunch(state, self) or (
+                            HasClub(state, self) and HasFlyer(state, self)))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value, lambda state: NoRequirement())
+
+    # 5-2
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L2Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Water.value, lambda state: True)
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Caverns.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Storm.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Qube.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Ranix.value,
+                    lambda state: CanSwim(state, self) or HasSling(state, self) or (
+                            HasHoop(state, self) and HasFlyer(state, self)))
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sharpe.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sticky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Droog.value,
+                    lambda state: CanDive(state, self) or HasFlyer(state, self) or HasSling(state, self))
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Gash.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Kundra.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Shadow.value, lambda state: NoRequirement())
+
+    # 5-3
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Spring.value, lambda state: True)
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Cave.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Punky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Ameego.value,
+                    lambda state: CanDive(state, self))
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Yoky.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Jory.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Crank.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Claxter.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Looza.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Cave.value, AERoom.W5L3Roti.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W5L3Cave.value, AERoom.W5L3Dissa.value,
+                    lambda state: CanHitOnce(state, self))
+
+    # 7-1
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Temple.value, lambda state: True)
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Well.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Taku.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Rocka.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Wog.value,
+                    lambda state: HasClub(state, self) or HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Mayi.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Owyang.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Long.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Elly.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
+                    lambda state: HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self))
+                                  or SuperFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
+
+    # 7-2
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L2First.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Gong.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Middle.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Middle.value, AERoom.W7L2Course.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Barrel.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Minky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Zobbro.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Xeeto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Moops.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Zanabi.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Middle.value, AERoom.W7L2Doxs.value,
+                    lambda state: WSW_ThirdRoom(state, self))
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Buddha.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self))
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
+                    lambda state: WSW_ThirdRoom(state, self) and RCMonkey(state, self))
+    connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
+                            HasSling(state, self) or HasHoop(state, self)))
+    connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
+                            HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
+
+    # 7-3
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Castle.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Basement.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Button.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Elevator.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Bell.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Robart.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Igor.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Naners.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Neeners.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Charles.value,
+                    lambda state: HasPunch(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Gustav.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Wilhelm.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Emmanuel.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3SirCutty.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Calligan.value,
+                    lambda state: CC_WaterRoom(state, self) and (
+                            CanDive(state, self) or HasPunch(state, self)))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Castalist.value,
+                    lambda state: CC_WaterRoom(state, self) and CanDive(state, self))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Deveneom.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Button.value, AERoom.W7L3Astur.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Button.value, AERoom.W7L3Kilserack.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Ringo.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Densil.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Figero.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Fej.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Joey.value,
+                    lambda state: HasMobility(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Donqui.value, lambda state: NoRequirement())
+
+    # 8-1
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Sewers.value, lambda state: True)
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Barrel.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
+                    lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
+                    or HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
+                    lambda state: (CP_FrontSewer(state, self) or CP_BackSewer(state, self))
+                    and HasRC(state, self))
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
+                    lambda state: (CP_FrontSewer(state, self) and HasRC(state, self))
+                    or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
+                    lambda state: ((CP_FrontSewer(state, self) or CP_BackSewer(state, self))
+                                   and HasRC(state, self)) or HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
+                    lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
+                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+                    and CanDive(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
+                    lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
+                    lambda state: (CP_FrontBarrels(state, self) and (CanSwim(state, self)
+                                                                       or HasSling(state, self)
+                                                                       or HasFlyer(state, self)))
+                    or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
+                    lambda state: ((CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+                                   and CanDive(state, self)) or (HasSling(state, self)
+                                                                   and HasRC(state, self)))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
+                    lambda state: (CP_FrontBarrels(state, self)
+                                   and (HasHoop(state, self) or CanSwim(state, self))
+                                   and HasFlyer(state, self)) or CP_BackSewer(state, self)
+                    or HasSling(state, self))
+
+    # 8-2
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2Factory.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2RC.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Mech.value, AERoom.W8L2Lava.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Conveyor.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2Mech.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2BigShow.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2Dreos.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2Reznor.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2RC.value, AERoom.W8L2Urkel.value,
+                    lambda state: SF_CarRoom(state, self) or HasSling(state, self) or SuperFlyer(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2VanillaS.value,
+                    lambda state: SF_MechRoom(state, self) and HasPunch(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Radd.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Shimbo.value,
+                    lambda state: SF_MechRoom(state, self) and RCMonkey(state, self))
+    connect_regions(self, AERoom.W8L2Conveyor.value, AERoom.W8L2Hurt.value,
+                    lambda state: SF_MechRoom(state, self) and CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W8L2Conveyor.value, AERoom.W8L2String.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2Mech.value, AERoom.W8L2Khamo.value,
+                    lambda state: SF_MechRoom(state, self) and CanHitMultiple(state, self))
+
+    # 8-3
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Water.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Outside.value, AERoom.W8L3Lobby.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Tank.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Fan.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L3Outside.value, AERoom.W8L3Fredo.value,
+                    lambda state: HasPunch(state, self))
+    connect_regions(self, AERoom.W8L3Water.value, AERoom.W8L3Charlee.value,
+                    lambda state: TVT_HitButton(state, self))
+    connect_regions(self, AERoom.W8L3Water.value, AERoom.W8L3Mach3.value,
+                    lambda state: TVT_HitButton(state, self))
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Tortuss.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Manic.value,
+                    lambda state: HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Ruptdis.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Eighty7.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Danio.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Roosta.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Tellis.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Whack.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Frostee.value,
+                    lambda state: TVT_TankRoom(state, self))
+
+    # 9-1
+    connect_regions(self, AEWorld.W9.value, AERoom.W9L1Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Haunted.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Haunted.value, AERoom.W9L1Coffin.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Natalie.value,
+                    lambda state: MM_Natalie(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Professor.value,
+                    lambda state: MM_Professor(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Jake.value,
+                    lambda state: MM_Jake(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Western.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Crater.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Crater.value, AERoom.W9L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Castle.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Climb1.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Climb2.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Head.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Side.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Boss.value,
+                    lambda state: MM_FinalBoss(state, self))
+
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Goopo.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Haunted.value, AERoom.W9L1Porto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Slam.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Junk.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Crib.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Nak.value,
+                    lambda state: HasSling(state, self) or HasHoop(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Cloy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Shaw.value,
+                    lambda state: HasSling(state, self) or HasHoop(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Flea.value,
+                    lambda state: HasSling(state, self) or HasHoop(state, self))
+    connect_regions(self, AERoom.W9L1Crater.value, AERoom.W9L1Schafette.value,
+                    lambda state: MM_SHA(state, self) and HasFlyer(state, self))
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Donovan.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Laura.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Uribe.value,
+                    lambda state: MM_UFODoor(state, self) and HasPunch(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Gordo.value,
+                    lambda state: MM_UFODoor(state, self) and (HasFlyer(state, self) or HasRC(state, self)))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Raeski.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Poopie.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Teacup.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Shine.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb2.value, AERoom.W9L1Wrench.value,
+                    lambda state: MM_SpaceMonkeys(state, self))
+    connect_regions(self, AERoom.W9L1Climb2.value, AERoom.W9L1Bronson.value,
+                    lambda state: MM_SpaceMonkeys(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Bungee.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Carro.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Carlito.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Side.value, AERoom.W9L1BG.value,
+                    lambda state: MM_SHA(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
+
+    self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player, 1)
+
+    if self.options.coin == "true":
+        # Coins
         # 1-1
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Noonan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Jorjy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Nati.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value, lambda state: NoRequirement())
-
+        connect_regions(self, AERoom.W1L1Main.value, AERoom.Coin1.value, lambda state: NoRequirement())
         # 1-2
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L2Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Shay.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2DrMonk.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Grunt.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Ahchoo.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Gornif.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Tyrone.value, lambda state: NoRequirement())
-
+        connect_regions(self, AERoom.W1L2Main.value, AERoom.Coin2.value,
+                        lambda state: CanDive(state, self))
         # 1-3
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L3Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Volcano.value, lambda state: True)
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Triceratops.value,
-                        lambda state: HasSling(state, player))
-
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Scotty.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Coco.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3JThomas.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Moggan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Volcano.value, AERoom.W1L3Barney.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Volcano.value, AERoom.W1L3Mattie.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Triceratops.value, AERoom.W1L3Rocky.value,
-                        lambda state: HasSling(state, player))
-
+        connect_regions(self, AERoom.W1L3Entry.value, AERoom.Coin3.value, lambda state: NoRequirement())
         # 2-1
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L1Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Mushroom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Fish.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Tent.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Boulder.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Marquez.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Livinston.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1George.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Gonzo.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Zanzibar.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
-                        lambda state: TJ_FishEntry(state, player) and (
-                                HasSling(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
-                        lambda state: TJ_FishEntry(state, player))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Stoddy.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Mitong.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value, lambda state: ((TJ_FishEntry(
-            state, player) or (TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player))) and CanHitMultiple(state,
-                                                                                                              player)))
-        connect_regions(world, player, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value, lambda state: (
-                TJ_UFOEntry(state, player) or (TJ_FishEntry(state, player)) and CanHitMultiple(state, player)))
-        connect_regions(world, player, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value, lambda state: (
-                (TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)) or (TJ_FishEntry(state, player))
-                and CanHitMultiple(state, player)) and (HasClub(state, player) or HasSling(state, player)
-                                                        or HasFlyer(state, player)))
-
+        connect_regions(self, AERoom.W2L1Entry.value, AERoom.Coin6.value,
+                        lambda state: HasMobility(state, self))
+        connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.Coin7.value,
+                        lambda state: TJ_Mushroom(state, self))
+        connect_regions(self, AERoom.W2L1Fish.value, AERoom.Coin8.value,
+                        lambda state: (TJ_FishEntry(state, self)))
+        connect_regions(self, AERoom.W2L1Tent.value, AERoom.Coin9.value,
+                        lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                                (TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
         # 2-2
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Fan.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Obelisk.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Water.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Kyle.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Stan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Kenny.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Cratman.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Mooshy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.W2L2Nuzzy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.W2L2Mav.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Papou.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Trance.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
-                        lambda state: HasSling(state, player) or HasPunch(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
-                        lambda state: (CanSwim(state, player) and CanHitOnce(state, player)) or HasSling(state, player)
-                        or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
-                        lambda state: CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
-                        lambda state: (CanSwim(state, player) and CanHitOnce(state, player)) or HasSling(state, player)
-                        or HasHoop(state, player))
-
-        #2-3
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Side.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Main.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Pillar.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Bazzle.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Freeto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L3Side.value, AERoom.W2L3Troopa.value,
-                        lambda state: (HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
-                        lambda state: CR_Inside(state, player))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
-                        lambda state: CR_Inside(state, player) and (
-                                (CanSwim(state, player) and CanHitMultiple(state, player)) or HasSling(state, player)
-                                or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
-                        lambda state: CR_Inside(state, player) and (CanHitMultiple(state, player) or (
-                                CanSwim(state, player) and HasMobility(state, player))))
-        connect_regions(world, player, AERoom.W2L3Pillar.value, AERoom.W2L3Pally.value,
-                        lambda state: CR_Inside(state, player))
-        connect_regions(world, player, AERoom.W2L3Pillar.value, AERoom.W2L3Crash.value,
-                        lambda state: CR_Inside(state, player) and (RCMonkey(state, player) or SuperFlyer(state, player)))
+        connect_regions(self, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
+                        lambda state: (HasHoop(state, self) and HasFlyer(state, self)) or
+                                      HasSling(state, self) or HasRC(state, self) or HasPunch(state, self))
+        connect_regions(self, AERoom.W2L2Water.value, AERoom.Coin14.value,
+                        lambda state: CanDive(state, self) and CanHitOnce(state, self))
+        # 2-3
+        connect_regions(self, AERoom.W2L3Main.value, AERoom.Coin17.value,
+                        lambda state: CR_Inside(state, self)
+                                      and (CanSwim(state, self) or HasMobility(state, self)))
+        # 3-1
+        connect_regions(self, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, self))
 
         # 4-1
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L1FirstRoom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1SecondRoom.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1CoolBlue.value,
+        connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.Coin21.value,
                         lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1Sandy.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1ShellE.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1Gidget.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Shaka.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Puka.value,
-                        lambda state: CanHitMultiple(state, player) or HasHoop(state, player)
-                        or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1MaxMahalo.value,
-                        lambda state: HasHoop(state, player) or HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Moko.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
 
         # 4-2
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L2FirstRoom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2SecondRoom.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Chip.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
-                        lambda state: (HasMobility(state, player)))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
-                        lambda state: CanDive(state, player) or HasSling(state, player) or (
-                                HasHoop(state, player) and HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value,
-                        lambda state: (HasMobility(state, player)))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
-                        lambda state: CanSwim(state, player) or HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2BongBong.value,
-                        lambda state: CanSwim(state, player) or HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Jux.value,
-                        lambda state: CanSwim(state, player) or HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Pickles.value,
-                        lambda state: (CanSwim(state, player) and CanHitMultiple(state, player))
-                        or HasSling(state, player))
+        connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.Coin23.value,
+                        lambda state: CanDive(state, self) or (CanSwim(state, self) and HasRC(state, self)))
 
         # 4-3
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3Stomach.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Slide.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Slide.value, AERoom.W4L3Gallery.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Tentacle.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3TonTon.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3Stuw.value,
-                        lambda state: CanSwim(state, player) or CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Mars.value,
-                        lambda state: HasRC(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Murky.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Horke.value,
-                        lambda state: CanHitOnce(state, player) and (
-                                CanSwim(state, player) or HasSling(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Howeerd.value,
-                        lambda state: DI_SecondHalf(state, player) and (
-                                HasSling(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Robbin.value,
-                        lambda state: DI_SecondHalf(state, player) and (
-                                HasSling(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Jakkee.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Frederic.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Baba.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Tentacle.value, AERoom.W4L3Quirck.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
+        connect_regions(self, AERoom.W4L3Outside.value, AERoom.Coin24.value,
+                        lambda state: CanSwim(state, self) or CanHitOnce(state, self))
+        connect_regions(self, AERoom.W4L3Stomach.value, AERoom.Coin25.value,
+                        lambda state: CanDive(state, self) and CanHitOnce(state, self))
+        connect_regions(self, AERoom.W4L3Slide.value, AERoom.Coin28.value,
+                        lambda state: (CanHitOnce(state, self)) or HasPunch(state, self))
+        # CanHitOnce and Net, if Net is shuffled.
 
         # 5-1
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L1Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Popcicle.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
-                        lambda state: HasSling(state, player) or HasPunch(state, player) or (
-                                HasClub(state, player) and HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W5L1Main.value, AERoom.Coin29.value,
+                        lambda state: NoRequirement())
 
         # 5-2
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L2Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Water.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Caverns.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Storm.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Qube.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Ranix.value,
-                        lambda state: CanSwim(state, player) or HasSling(state, player) or (
-                                HasHoop(state, player) and HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Sharpe.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Sticky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Droog.value,
-                        lambda state: CanDive(state, player) or HasFlyer(state, player) or HasSling(state, player))
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Gash.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Kundra.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Shadow.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W5L2Entry.value, AERoom.Coin30.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W5L2Water.value, AERoom.Coin31.value,
+                        lambda state: CanDive(state, self))
+        connect_regions(self, AERoom.W5L2Caverns.value, AERoom.Coin32.value,
+                        lambda state: NoRequirement())
 
         # 5-3
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Spring.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Cave.value, lambda state: True)
+        connect_regions(self, AERoom.W5L3Spring.value, AERoom.Coin34.value,
+                        lambda state: HasSling(state, self) or HasFlyer(state, self))
+        connect_regions(self, AERoom.W5L3Cave.value, AERoom.Coin35.value,
+                        lambda state: CanHitOnce(state, self))
 
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Punky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Ameego.value,
-                        lambda state: CanDive(state, player))
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Yoky.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Jory.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Crank.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Claxter.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Looza.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.W5L3Roti.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.W5L3Dissa.value,
-                        lambda state: CanHitOnce(state, player))
+        # 6-1
+        connect_regions(self, AEWorld.W6.value, AERoom.Coin36.value, lambda state: HasFlyer(state, self))
 
         # 7-1
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Temple.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Well.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Taku.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Rocka.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value,
+        connect_regions(self, AERoom.W7L1Outside.value, AERoom.Coin37.value,
                         lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Wog.value,
-                        lambda state: HasClub(state, player) or HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Mayi.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Owyang.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Long.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Elly.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
-                        lambda state: HasSling(state, player) or (HasHoop(state, player) and HasFlyer(state, player)) or SuperFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L1Temple.value, AERoom.Coin38.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L1Well.value, AERoom.Coin39.value,
+                        lambda state: HasSling(state, self) or HasFlyer(state, self))
 
         # 7-2
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L2First.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Gong.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Middle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Middle.value, AERoom.W7L2Course.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Barrel.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Minky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Zobbro.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Xeeto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Moops.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Zanabi.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Middle.value, AERoom.W7L2Doxs.value,
-                        lambda state: WSW_ThirdRoom(state, player))
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Buddha.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player))
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
-                        lambda state: WSW_ThirdRoom(state, player) and RCMonkey(state, player))
-        connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player) and (
-                                HasSling(state, player) or HasHoop(state, player)))
-        connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player) and (
-                                HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player)))
+        connect_regions(self, AERoom.W7L2First.value, AERoom.Coin40.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L2Gong.value, AERoom.Coin41.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L2Barrel.value, AERoom.Coin43.value,
+                        lambda state: HasSling(state, self) or HasFlyer(state, self))
 
         # 7-3
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Castle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Basement.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Button.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Elevator.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Bell.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Robart.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Igor.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Naners.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Neeners.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Charles.value,
-                        lambda state: HasPunch(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Gustav.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Wilhelm.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Emmanuel.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3SirCutty.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Calligan.value,
-                        lambda state: CC_WaterRoom(state, player) and (
-                                CanDive(state, player) or HasPunch(state, player)))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Castalist.value,
-                        lambda state: CC_WaterRoom(state, player) and CanDive(state, player))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Deveneom.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Button.value, AERoom.W7L3Astur.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Button.value, AERoom.W7L3Kilserack.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Ringo.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Densil.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Figero.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Fej.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Joey.value,
-                        lambda state: HasMobility(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Donqui.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L3Outside.value, AERoom.Coin45.value,
+                        lambda state: HasClub(state, self) or HasSling(state, self) or HasHoop(state, self)
+                                      or HasFlyer(state, self) or HasPunch(state, self))
+        connect_regions(self, AERoom.W7L3Castle.value, AERoom.Coin46.value,
+                        lambda state: CC_5Monkeys(state, self) or HasSling(state, self))
+        connect_regions(self, AERoom.W7L3Button.value, AERoom.Coin49.value,
+                        lambda state: CC_ButtonRoom(state, self))
+        connect_regions(self, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
+                        lambda state: CC_5Monkeys(state, self) or CC_WaterRoom(state, self) or
+                                      HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self)))
 
         # 8-1
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Sewers.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1Barrel.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
-                        lambda state: (CP_FrontBarrels(state, player) and CanDive(state, player))
-                        or HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
-                        lambda state: (CP_FrontSewer(state, player) or CP_BackSewer(state, player))
-                        and HasRC(state, player))
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
-                        lambda state: (CP_FrontSewer(state, player) and HasRC(state, player))
-                        or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
-                        lambda state: ((CP_FrontSewer(state, player) or CP_BackSewer(state, player))
-                                       and HasRC(state, player)) or HasSling(state,player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
-                        lambda state: CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
-                        lambda state: (CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-                        and CanDive(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
-                        lambda state: CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
-                        lambda state: (CP_FrontBarrels(state, player) and (CanSwim(state, player)
-                                                                           or HasSling(state, player)
-                                                                           or HasFlyer(state, player)))
-                        or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
-                        lambda state: ((CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-                                       and CanDive(state, player)) or (HasSling(state, player)
-                                                                       and HasRC(state, player)))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
-                        lambda state: (CP_FrontBarrels(state, player)
-                                       and (HasHoop(state, player) or CanSwim(state, player))
-                                       and HasFlyer(state, player)) or CP_BackSewer(state, player)
-                        or HasSling(state, player))
+        connect_regions(self, AERoom.W8L1Outside.value, AERoom.Coin53.value,
+                        lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
+                                      or HasSling(state, self) or HasFlyer(state, self))
+        connect_regions(self, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
+                        lambda state: (CP_FrontSewer(state, self)
+                                       and (HasRC(state, self) or HasSling(state, self)
+                                            or SuperFlyer(state, self))) or (CP_BackSewer(state, self)
+                                                                               and HasRC(state, self)
+                                                                               or HasSling(state, self)))
+        connect_regions(self, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
+                        lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+                                      and (HasSling(state, self) or HasFlyer(state, self)))
 
         # 8-2
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2Factory.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2RC.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Mech.value, AERoom.W8L2Lava.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Conveyor.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2Mech.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2BigShow.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2Dreos.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2Reznor.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2RC.value, AERoom.W8L2Urkel.value,
-                        lambda state: SF_CarRoom(state, player) or HasSling(state, player) or SuperFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2VanillaS.value,
-                        lambda state: SF_MechRoom(state, player) and HasPunch(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Radd.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Shimbo.value,
-                        lambda state: SF_MechRoom(state, player) and RCMonkey(state, player))
-        connect_regions(world, player, AERoom.W8L2Conveyor.value, AERoom.W8L2Hurt.value,
-                        lambda state: SF_MechRoom(state, player) and CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W8L2Conveyor.value, AERoom.W8L2String.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2Mech.value, AERoom.W8L2Khamo.value,
-                        lambda state: SF_MechRoom(state, player) and CanHitMultiple(state, player))
+        connect_regions(self, AERoom.W8L2RC.value, AERoom.Coin58.value,
+                        lambda state: SF_CarRoom(state, self) or SuperFlyer(state, self))
+        connect_regions(self, AERoom.W8L2Lava.value, AERoom.Coin62.value,
+                        lambda state: SF_MechRoom(state, self))
 
         # 8-3
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Water.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Outside.value, AERoom.W8L3Lobby.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Tank.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Fan.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L3Outside.value, AERoom.W8L3Fredo.value,
-                        lambda state: HasPunch(state, player))
-        connect_regions(world, player, AERoom.W8L3Water.value, AERoom.W8L3Charlee.value,
-                        lambda state: TVT_HitButton(state, player))
-        connect_regions(world, player, AERoom.W8L3Water.value, AERoom.W8L3Mach3.value,
-                        lambda state: TVT_HitButton(state, player))
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Tortuss.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Manic.value,
-                        lambda state: HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Ruptdis.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Eighty7.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Danio.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Roosta.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Tellis.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Whack.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Frostee.value,
-                        lambda state: TVT_TankRoom(state, player))
+        connect_regions(self, AERoom.W8L3Water.value, AERoom.Coin64.value,
+                        lambda state: HasSling(state, self) or HasFlyer(state, self))
+        connect_regions(self, AERoom.W8L3Tank.value, AERoom.Coin66.value,
+                        lambda state: TVT_TankRoom(state, self))
 
         # 9-1
-        connect_regions(world, player, AEWorld.W9.value, AERoom.W9L1Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Haunted.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.W9L1Coffin.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Natalie.value,
-                        lambda state: MM_Natalie(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Professor.value,
-                        lambda state: MM_Professor(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Jake.value,
-                        lambda state: MM_Jake(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Western.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Crater.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.W9L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Castle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Climb1.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Climb2.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Head.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Side.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Boss.value,
-                        lambda state: MM_FinalBoss(state, player))
-
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Goopo.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.W9L1Porto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Slam.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Junk.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Crib.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Nak.value,
-                        lambda state: HasSling(state, player) or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Cloy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Shaw.value,
-                        lambda state: HasSling(state, player) or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Flea.value,
-                        lambda state: HasSling(state, player) or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.W9L1Schafette.value,
-                        lambda state: MM_SHA(state, player) and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Donovan.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Laura.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Uribe.value,
-                        lambda state: MM_UFODoor(state, player) and HasPunch(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Gordo.value,
-                        lambda state: MM_UFODoor(state, player) and (HasFlyer(state, player) or HasRC(state, player)))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Raeski.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Poopie.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Teacup.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Shine.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.W9L1Wrench.value,
-                        lambda state: MM_SpaceMonkeys(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.W9L1Bronson.value,
-                        lambda state: MM_SpaceMonkeys(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Bungee.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Carro.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Carlito.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Side.value, AERoom.W9L1BG.value,
-                        lambda state: MM_SHA(state, player) and (HasSling(state, player) or HasFlyer(state, player)))
-
-        world.completion_condition[player] = lambda state: state.has("Victory", player, 1)
-
-        if coins:
-            # Coins
-            # 1-1
-            connect_regions(world, player, AERoom.W1L1Main.value, AERoom.Coin1.value, lambda state: NoRequirement())
-            # 1-2
-            connect_regions(world, player, AERoom.W1L2Main.value, AERoom.Coin2.value,
-                            lambda state: CanDive(state, player))
-            # 1-3
-            connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.Coin3.value, lambda state: NoRequirement())
-            # 2-1
-            connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.Coin6.value,
-                            lambda state: HasMobility(state, player))
-            connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.Coin7.value,
-                            lambda state: TJ_Mushroom(state, player))
-            connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.Coin8.value,
-                            lambda state: (TJ_FishEntry(state, player)))
-            connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.Coin9.value,
-                            lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                    (TJ_UFOEntry(state, player)) and (TJ_UFOCliff(state, player))))
-            # 2-2
-            connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
-                            lambda state: (HasHoop(state, player) and HasFlyer(state, player)) or
-                                    HasSling(state, player) or HasRC(state, player) or HasPunch(state, player))
-            connect_regions(world, player, AERoom.W2L2Water.value, AERoom.Coin14.value,
-                            lambda state: CanDive(state, player) and CanHitOnce(state, player))
-            # 2-3
-            connect_regions(world, player, AERoom.W2L3Main.value, AERoom.Coin17.value,
-                            lambda state: CR_Inside(state, player) and
-                                    (CanSwim(state, player) or HasMobility(state, player)))
-            # 3-1
-            connect_regions(world, player, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, player))
-
-            # 4-1
-            connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.Coin21.value,
-                            lambda state: NoRequirement())
-
-            # 4-2
-            connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.Coin23.value,
-                            lambda state: CanDive(state, player) or (CanSwim(state, player) and HasRC(state, player)))
-
-            # 4-3
-            connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.Coin24.value,
-                            lambda state: CanSwim(state, player) or CanHitOnce(state, player))
-            connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.Coin25.value,
-                            lambda state: CanDive(state, player) and CanHitOnce(state, player))
-            connect_regions(world, player, AERoom.W4L3Slide.value, AERoom.Coin28.value,
-                            lambda state: (CanHitOnce(state, player)) or HasPunch(state, player))
-            #CanHitOnce and Net, if Net is shuffled.
-
-            # 5-1
-            connect_regions(world, player, AERoom.W5L1Main.value, AERoom.Coin29.value,
-                            lambda state: NoRequirement())
-
-            # 5-2
-            connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.Coin30.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W5L2Water.value, AERoom.Coin31.value,
-                            lambda state: CanDive(state, player))
-            connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.Coin32.value,
-                            lambda state: NoRequirement())
-
-            # 5-3
-            connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.Coin34.value,
-                            lambda state: HasSling(state, player) or HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.Coin35.value,
-                            lambda state: CanHitOnce(state, player))
-
-            # 6-1
-            connect_regions(world, player, AEWorld.W6.value, AERoom.Coin36.value, lambda state: HasFlyer(state, player))
-
-            # 7-1
-            connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.Coin37.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.Coin38.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L1Well.value, AERoom.Coin39.value,
-                            lambda state: HasSling(state, player) or HasFlyer(state, player))
-
-            # 7-2
-            connect_regions(world, player, AERoom.W7L2First.value, AERoom.Coin40.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.Coin41.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.Coin43.value,
-                            lambda state: HasSling(state, player) or HasFlyer(state, player))
-
-            # 7-3
-            connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.Coin45.value,
-                            lambda state: HasClub(state, player) or HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player) or HasPunch(state, player))
-            connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.Coin46.value,
-                            lambda state: CC_5Monkeys(state, player) or HasSling(state, player))
-            connect_regions(world, player, AERoom.W7L3Button.value, AERoom.Coin49.value,
-                            lambda state: CC_ButtonRoom(state, player))
-            connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
-                            lambda state: CC_5Monkeys(state, player) or CC_WaterRoom(state, player) or
-                                    HasSling(state, player) or
-                                            (HasHoop(state, player) and HasFlyer(state, player)))
-
-            # 8-1
-            connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.Coin53.value,
-                            lambda state: (CP_FrontBarrels(state, player) and CanDive(state, player)) or
-                                    HasSling(state, player) or HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
-                            lambda state: (CP_FrontSewer(state, player) and (HasRC(state, player) or HasSling(state, player) or SuperFlyer(state, player))) or (CP_BackSewer(state, player) and HasRC(state, player) or HasSling(state, player)))
-            connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
-                            lambda state: (CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-                                    and (HasSling(state, player) or HasFlyer(state, player)))
-
-            # 8-2
-            connect_regions(world, player, AERoom.W8L2RC.value, AERoom.Coin58.value,
-                            lambda state: SF_CarRoom(state, player) or SuperFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.Coin62.value,
-                            lambda state: SF_MechRoom(state, player))
-
-            # 8-3
-            connect_regions(world, player, AERoom.W8L3Water.value, AERoom.Coin64.value,
-                            lambda state: HasSling(state, player) or HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.Coin66.value,
-                            lambda state: TVT_TankRoom(state, player))
-
-            # 9-1
-            connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.Coin73.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.Coin74.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.Coin75.value,
-                            lambda state: HasSling(state, player) or HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W9L1Western.value, AERoom.Coin77.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.Coin78.value,
-                            lambda state: MM_SHA(state, player) and
-                                    (HasSling(state, player) or HasFlyer(state, player)))
-            connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.Coin79.value,
-                            lambda state: MM_SHA(state, player))
-            connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.Coin80.value,
-                            lambda state: MM_UFODoor(state, player))
-            connect_regions(world, player, AERoom.W9L1Head.value, AERoom.Coin84.value,
-                            lambda state: MM_DoubleDoor(state, player))
-            connect_regions(world, player, AERoom.W9L1Side.value, AERoom.Coin85.value,
-                            lambda state: MM_SHA(state, player) and
-                                    (HasSling(state, player) or HasFlyer(state, player)))
-            connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.Coin82.value,
-                            lambda state: MM_SpaceMonkeys(state, player))
+        connect_regions(self, AERoom.W9L1Entry.value, AERoom.Coin73.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Entry.value, AERoom.Coin74.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Haunted.value, AERoom.Coin75.value,
+                        lambda state: HasSling(state, self) or HasFlyer(state, self))
+        connect_regions(self, AERoom.W9L1Western.value, AERoom.Coin77.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Crater.value, AERoom.Coin78.value,
+                        lambda state: MM_SHA(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
+        connect_regions(self, AERoom.W9L1Outside.value, AERoom.Coin79.value,
+                        lambda state: MM_SHA(state, self))
+        connect_regions(self, AERoom.W9L1Castle.value, AERoom.Coin80.value,
+                        lambda state: MM_UFODoor(state, self))
+        connect_regions(self, AERoom.W9L1Head.value, AERoom.Coin84.value,
+                        lambda state: MM_DoubleDoor(state, self))
+        connect_regions(self, AERoom.W9L1Side.value, AERoom.Coin85.value,
+                        lambda state: MM_SHA(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
+        connect_regions(self, AERoom.W9L1Climb2.value, AERoom.Coin82.value,
+                        lambda state: MM_SpaceMonkeys(state, self))
 
 
-def Keys(state, player, count):
-    return state.has(AEItem.Key.value, player, count)
+def Keys(state, world, count):
+    return state.has(AEItem.Key.value, world.player, count)
 
 
 def NoRequirement():
     return True
 
 
-def CanHitOnce(state, player):
-    return HasClub(state, player) or HasRadar(state, player) or HasSling(state, player) or HasHoop(state,player) or HasFlyer(state, player) or HasRC(state, player) or HasPunch(state, player)
+def CanHitOnce(state, world):
+    return (HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(state, world)
+            or HasFlyer(state, world) or HasRC(state, world) or HasPunch(state, world))
 
 
-def CanHitMultiple(state, player):
-    return HasClub(state, player) or HasSling(state, player) or HasHoop(state, player) or HasPunch(state, player)
+def CanHitMultiple(state, world):
+    return HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasPunch(state, world)
 
 
-def HasMobility(state, player):
-    return HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player)
+def HasMobility(state, world):
+    return HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world)
 
 
-def RCMonkey(state, player):
-    return HasSling(state, player) or HasRC(state, player)
+def RCMonkey(state, world):
+    return HasSling(state, world) or HasRC(state, world)
 
 
-def CanSwim(state, player):
-    return HasWaterNet(state, player)
+def CanSwim(state, world):
+    return HasWaterNet(state, world)
 
 
-def CanDive(state, player):
-    return HasWaterNet(state, player)
+def CanDive(state, world):
+    return HasWaterNet(state, world)
 
 
-def CanWaterCatch(state, player):
-    return HasWaterNet(state, player)
+def CanWaterCatch(state, world):
+    return HasWaterNet(state, world)
 
 
-def SuperFlyer(state, player):
-    return HasFlyer(state, player) and (HasNet(state, player) or HasClub(state, player) or HasSling(state, player) or HasPunch(state, player)) and SuperFlyerOption
+def SuperFlyer(state, world):
+    return HasFlyer(state, world) and (HasNet(state, world) or HasClub(state, world) or HasSling(state, world)
+                                        or HasPunch(state, world)) and world.options.superflyer == "true"
 
 
-def TJ_UFOEntry(state, player):
-    return CanDive(state, player)
+def TJ_UFOEntry(state, world):
+    return CanDive(state, world)
 
 
-def TJ_UFOCliff(state, player):
+def TJ_UFOCliff(state, world):
     return True
 
 
-def TJ_FishEntry(state, player):
-    return CanSwim(state, player) or HasFlyer(state, player)
+def TJ_FishEntry(state, world):
+    return CanSwim(state, world) or HasFlyer(state, world)
 
 
-def TJ_Mushroom(state, player):
-    return (HasMobility(state, player) and CanHitMultiple(state, player)) or SuperFlyer(state, player)
+def TJ_Mushroom(state, world):
+    return (HasMobility(state, world) and CanHitMultiple(state, world)) or SuperFlyer(state, world)
 
 
-def CR_Inside(state, player):
-    return HasSling(state, player) or HasPunch(state, player)
+def CR_Inside(state, world):
+    return HasSling(state, world) or HasPunch(state, world)
 
 
-def DI_SecondHalf(state, player):
-    return HasSling(state, player) or (CanHitMultiple(state, player) and CanDive(state, player))
+def DI_SecondHalf(state, world):
+    return HasSling(state, world) or (CanHitMultiple(state, world) and CanDive(state, world))
 
 
-def DI_Boulders(state, player):
-    return HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player) or HasRC(state, player)
+def DI_Boulders(state, world):
+    return HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasRC(state, world)
 
 
-def WSW_ThirdRoom(state, player):
-    return HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player)
+def WSW_ThirdRoom(state, world):
+    return HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world)
 
 
-def WSW_FourthRoom(state, player):
+def WSW_FourthRoom(state, world):
     return True
 
 
-def CC_5Monkeys(state, player):
-    return HasClub(state, player) or HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player) or HasPunch(state, player)
+def CC_5Monkeys(state, world):
+    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world)
+            or HasPunch(state, world))
 
 
-def CC_WaterRoom(state, player):
-    return (CanHitMultiple(state, player) and HasNet(state, player)) or (CanDive(state, player) and (HasFlyer(state, player) or HasPunch(state, player))) or (HasFlyer(state, player) or HasHoop(state, player)) or HasSling(state, player) or SuperFlyer(state, player)
+def CC_WaterRoom(state, world):
+    return ((CanHitMultiple(state, world) and HasNet(state, world))
+            or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world)))
+            or HasFlyer(state, world) or HasHoop(state, world) or HasSling(state, world)
+            or SuperFlyer(state, world))
 
 
-def CC_ButtonRoom(state, player):
-    return CC_WaterRoom(state, player) and (CanSwim(state, player) or HasFlyer(state, player))
+def CC_ButtonRoom(state, world):
+    return CC_WaterRoom(state, world) and (CanSwim(state, world) or HasFlyer(state, world))
 
 
-def CP_FrontSewer(state, player):
-    return HasSling(state, player) or HasRC(state, player)
+def CP_FrontSewer(state, world):
+    return HasSling(state, world) or HasRC(state, world)
 
 
-def CP_FrontBarrels(state, player):
-    return CP_FrontSewer(state, player) and (CanSwim(state, player) or HasMobility(state, player))
+def CP_FrontBarrels(state, world):
+    return CP_FrontSewer(state, world) and (CanSwim(state, world) or HasMobility(state, world))
 
 
-def CP_BackSewer(state, player):
-    return (HasSling(state, player) or HasFlyer(state, player)) and CanDive(state, player)
+def CP_BackSewer(state, world):
+    return (HasSling(state, world) or HasFlyer(state, world)) and CanDive(state, world)
 
 
-def SF_CarRoom(state, player):
-    return HasSling(state, player) or (HasHoop(state, player) and HasFlyer(state, player)) or HasRC(state, player) or HasPunch(state, player)
+def SF_CarRoom(state, world):
+    return (HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world)
+            or HasPunch(state, world))
 
 
-def SF_MechRoom(state, player):
-    return HasSling(state, player) or (HasHoop(state, player) and HasFlyer(state, player)) or (
-            HasClub(state, player) and HasRC(state, player)) or HasPunch(state, player) or SuperFlyer(state, player)
+def SF_MechRoom(state, world):
+    return HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or (
+            HasClub(state, world) and HasRC(state, world)) or HasPunch(state, world) or SuperFlyer(state, world)
 
 
-def TVT_HitButton(state, player):
-    return HasClub(state, player) or HasSling(state, player) or HasFlyer(state, player)
+def TVT_HitButton(state, world):
+    return HasClub(state, world) or HasSling(state, world) or HasFlyer(state, world)
 
 
-def TVT_TankRoom(state, player):
-    return TVT_HitButton(state, player)
+def TVT_TankRoom(state, world):
+    return TVT_HitButton(state, world)
 
 
-def MM_Natalie(state, player):
-    return CanHitMultiple(state, player)
+def MM_Natalie(state, world):
+    return CanHitMultiple(state, world)
 
 
-def MM_Professor(state, player):
-    return HasSling(state, player) or (HasFlyer(state, player) and (HasClub(state, player) or HasPunch(state, player)))
+def MM_Professor(state, world):
+    return HasSling(state, world) or (HasFlyer(state, world) and (HasClub(state, world) or HasPunch(state, world)))
 
 
-def Jake_Open(state, player):
-    return MM_Natalie(state, player) and MM_Professor(state, player)
+def Jake_Open(state, world):
+    return MM_Natalie(state, world) and MM_Professor(state, world)
 
 
-def MM_Jake(state, player):
-    return CanHitMultiple(state, player) and (HasSling(state, player) or Jake_Open(state, player))
+def MM_Jake(state, world):
+    return CanHitMultiple(state, world) and (HasSling(state, world) or Jake_Open(state, world))
 
 
-def MM_SHA(state, player):
-    return MM_Natalie(state, player) and MM_Professor(state, player) and MM_Jake(state, player)
+def MM_SHA(state, world):
+    return MM_Natalie(state, world) and MM_Professor(state, world) and MM_Jake(state, world)
 
 
-def MM_UFODoor(state, player):
-    return MM_SHA(state, player) and (HasClub(state, player) or HasSling(state, player) or HasPunch(state, player))
+def MM_UFODoor(state, world):
+    return MM_SHA(state, world) and (HasClub(state, world) or HasSling(state, world) or HasPunch(state, world))
 
 
-def MM_DoubleDoor(state, player):
-    return MM_UFODoor(state, player) and HasHoop(state, player) and HasRC(state, player)
+def MM_DoubleDoor(state, world):
+    return MM_UFODoor(state, world) and HasHoop(state, world) and HasRC(state, world)
 
 
-def MM_SpaceMonkeys(state, player):
-    return MM_DoubleDoor(state, player) and (HasSling(state, player) or HasFlyer(state, player))
+def MM_SpaceMonkeys(state, world):
+    return MM_DoubleDoor(state, world) and (HasSling(state, world) or HasFlyer(state, world))
 
 
-def MM_FinalBoss(state, player):
-    return MM_UFODoor(state, player) and (HasSling(state, player) or SuperFlyer(state, player))
+def MM_FinalBoss(state, world):
+    return MM_UFODoor(state, world) and (HasSling(state, world) or SuperFlyer(state, world))
 
 
-def HasClub(state, player):
-    return state.has(AEItem.Club.value, player, 1)
+def HasClub(state, world):
+    return state.has(AEItem.Club.value, world.player, 1)
 
 
-def HasNet(state, player):
-    return state.has(AEItem.Net.value, player, 1)
+def HasNet(state, world):
+    return state.has(AEItem.Net.value, world.player, 1)
 
 
-def HasRadar(state, player):
-    return state.has(AEItem.Radar.value, player, 1)
+def HasRadar(state, world):
+    return state.has(AEItem.Radar.value, world.player, 1)
 
 
-def HasSling(state, player):
-    return state.has(AEItem.Sling.value, player, 1)
+def HasSling(state, world):
+    return state.has(AEItem.Sling.value, world.player, 1)
 
 
-def HasHoop(state, player):
-    return state.has(AEItem.Hoop.value, player, 1)
+def HasHoop(state, world):
+    return state.has(AEItem.Hoop.value, world.player, 1)
 
 
-def HasFlyer(state, player):
-    return state.has(AEItem.Flyer.value, player, 1)
+def HasFlyer(state, world):
+    return state.has(AEItem.Flyer.value, world.player, 1)
 
 
-def HasRC(state, player):
-    return state.has(AEItem.Car.value, player, 1)
+def HasRC(state, world):
+    return state.has(AEItem.Car.value, world.player, 1)
 
 
-def HasPunch(state, player):
-    return state.has(AEItem.Punch.value, player, 1)
+def HasPunch(state, world):
+    return state.has(AEItem.Punch.value, world.player, 1)
 
 
-def HasWaterNet(state, player):
-    return state.has(AEItem.WaterNet.value, player, 1)
+def HasWaterNet(state, world):
+    return state.has(AEItem.WaterNet.value, world.player, 1)

--- a/worlds/apeescape/RulesIJ.py
+++ b/worlds/apeescape/RulesIJ.py
@@ -704,8 +704,7 @@ def NoRequirement():
 
 
 def CanHitOnce(state, world):
-    return (HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(state, world)
-            or HasFlyer(state, world) or HasRC(state, world) or HasPunch(state, world))
+    return (HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasRC(state, world) or HasPunch(state, world))
 
 
 def CanHitMultiple(state, world):
@@ -733,8 +732,7 @@ def CanWaterCatch(state, world):
 
 
 def SuperFlyer(state, world):
-    return HasFlyer(state, world) and (HasNet(state, world) or HasClub(state, world) or HasSling(state, world)
-                                        or HasPunch(state, world)) and world.options.superflyer == "true"
+    return HasFlyer(state, world) and (HasNet(state, world) or HasClub(state, world) or HasSling(state, world) or HasPunch(state, world)) and world.options.superflyer == "true"
 
 
 def TJ_UFOEntry(state, world):
@@ -774,15 +772,11 @@ def WSW_FourthRoom(state, world):
 
 
 def CC_5Monkeys(state, world):
-    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world)
-            or HasPunch(state, world))
+    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasPunch(state, world))
 
 
 def CC_WaterRoom(state, world):
-    return ((CanHitMultiple(state, world) and HasNet(state, world))
-            or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world)))
-            or HasFlyer(state, world) or HasHoop(state, world) or HasSling(state, world)
-            or SuperFlyer(state, world))
+    return ((CanHitMultiple(state, world) and HasNet(state, world)) or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world))) or HasFlyer(state, world) or HasHoop(state, world) or HasSling(state, world) or SuperFlyer(state, world))
 
 
 def CC_ButtonRoom(state, world):
@@ -802,13 +796,11 @@ def CP_BackSewer(state, world):
 
 
 def SF_CarRoom(state, world):
-    return (HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world)
-            or HasPunch(state, world))
+    return (HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world) or HasPunch(state, world))
 
 
 def SF_MechRoom(state, world):
-    return HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or (
-            HasClub(state, world) and HasRC(state, world)) or HasPunch(state, world) or SuperFlyer(state, world)
+    return HasSling(state, world) or (HasHoop(state, world) and HasFlyer(state, world)) or (HasClub(state, world) and HasRC(state, world)) or HasPunch(state, world) or SuperFlyer(state, world)
 
 
 def TVT_HitButton(state, world):

--- a/worlds/apeescape/RulesNoIJ.py
+++ b/worlds/apeescape/RulesNoIJ.py
@@ -697,14 +697,11 @@ def NoRequirement():
 
 
 def CanHitOnce(state, world):
-    return HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(
-        state, world) or HasFlyer(
-        state, world) or HasRC(state, world) or HasPunch(state, world)
+    return HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasRC(state, world) or HasPunch(state, world)
 
 
 def CanHitMultiple(state, world):
-    return HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasPunch(
-        state, world)
+    return HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasPunch(state, world)
 
 
 def HasMobility(state, world):
@@ -728,9 +725,7 @@ def CanWaterCatch(state, world):
 
 
 def SuperFlyer(state, world):
-    return HasFlyer(state, world) and (
-            HasNet(state, world) or HasClub(state, world) or HasSling(state, world)
-            or HasPunch(state, world)) and world.options.superflyer == "true"
+    return HasFlyer(state, world) and (HasNet(state, world) or HasClub(state, world) or HasSling(state, world) or HasPunch(state, world)) and world.options.superflyer == "true"
 
 
 def TJ_UFOEntry(state, world):
@@ -770,14 +765,11 @@ def WSW_FourthRoom(state, world):
 
 
 def CC_5Monkeys(state, world):
-    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world)
-            or HasFlyer(state, world) or HasPunch(state, world))
+    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasPunch(state, world))
 
 
 def CC_WaterRoom(state, world):
-    return ((CanHitMultiple(state, world) and HasNet(state, world))
-            or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world)))
-            or (HasFlyer(state, world) or HasHoop(state, world)) or SuperFlyer(state, world))
+    return ((CanHitMultiple(state, world) and HasNet(state, world)) or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world))) or (HasFlyer(state, world) or HasHoop(state, world)) or SuperFlyer(state, world))
 
 
 def CC_ButtonRoom(state, world):
@@ -802,9 +794,7 @@ def SF_CarRoom(state, world):
 
 
 def SF_MechRoom(state, world):
-    return ((HasHoop(state, world) and HasFlyer(state, world)) or (
-            HasClub(state, world) and (HasSling(state, world) or HasRC(state, world)))
-            or HasPunch(state, world) or SuperFlyer(state, world))
+    return ((HasHoop(state, world) and HasFlyer(state, world)) or (HasClub(state, world) and (HasSling(state, world) or HasRC(state, world))) or HasPunch(state, world) or SuperFlyer(state, world))
 
 
 def TVT_HitButton(state, world):
@@ -820,8 +810,7 @@ def MM_Natalie(state, world):
 
 
 def MM_Professor(state, world):
-    return HasFlyer(state, world) and (
-            HasClub(state, world) or HasSling(state, world) or HasPunch(state, world))
+    return HasFlyer(state, world) and (HasClub(state, world) or HasSling(state, world) or HasPunch(state, world))
 
 
 def Jake_Open(state, world):
@@ -837,8 +826,7 @@ def MM_SHA(state, world):
 
 
 def MM_UFODoor(state, world):
-    return MM_SHA(state, world) and (
-            HasClub(state, world) or HasSling(state, world) or HasPunch(state, world))
+    return MM_SHA(state, world) and (HasClub(state, world) or HasSling(state, world) or HasPunch(state, world))
 
 
 def MM_DoubleDoor(state, world):
@@ -850,8 +838,7 @@ def MM_SpaceMonkeys(state, world):
 
 
 def MM_FinalBoss(state, world):
-    return ((MM_DoubleDoor(state, world) and HasSling(state, world) and HasFlyer(state, world))
-            or (MM_UFODoor(state, world) and SuperFlyer(state, world)))
+    return ((MM_DoubleDoor(state, world) and HasSling(state, world) and HasFlyer(state, world)) or (MM_UFODoor(state, world) and SuperFlyer(state, world)))
 
 
 def HasClub(state, world):

--- a/worlds/apeescape/RulesNoIJ.py
+++ b/worlds/apeescape/RulesNoIJ.py
@@ -18,9 +18,7 @@ def set_noij_rules(self):
 
     if self.options.goal == "second":
         connect_regions(self, "Menu", AERoom.W9L2Boss.value,
-                        lambda state: Keys(state, self, 6) and HasSling(state, self)
-                                      and HasHoop(state, self) and HasFlyer(state, self)
-                                      and CanHitMultiple(state, self) and HasRC(state, self))
+                        lambda state: Keys(state, self, 6) and HasSling(state, self) and HasHoop(state, self) and HasFlyer(state, self) and CanHitMultiple(state, self) and HasRC(state, self))
 
     # 1-1
     connect_regions(self, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
@@ -74,8 +72,7 @@ def set_noij_rules(self):
     connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
                     lambda state: TJ_Mushroom(state, self))
     connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
-                    lambda state: TJ_FishEntry(state, self) and (
-                            HasSling(state, self) or HasFlyer(state, self)))
+                    lambda state: TJ_FishEntry(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
                     lambda state: TJ_FishEntry(state, self))
     connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
@@ -88,18 +85,11 @@ def set_noij_rules(self):
                     lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
                             TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
     connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
-                    lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self)
-                                                                    and TJ_UFOCliff(state, self)))
-                                   and CanHitMultiple(state, self)))
+                    lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))) and CanHitMultiple(state, self)))
     connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value,
-                    lambda state: (TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self))
-                                   and CanHitMultiple(state, self)))
+                    lambda state: (TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)))
     connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value,
-                    lambda state: ((TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))
-                                   or (TJ_FishEntry(state, self))
-                                   and CanHitMultiple(state, self)) and (HasClub(state, self)
-                                                                           or HasSling(state, self)
-                                                                           or HasFlyer(state, self)))
+                    lambda state: ((TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)) or (TJ_FishEntry(state, self)) and CanHitMultiple(state, self)) and (HasClub(state, self) or HasSling(state, self) or HasFlyer(state, self)))
 
     # 2-2
     connect_regions(self, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
@@ -121,13 +111,11 @@ def set_noij_rules(self):
     connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
                     lambda state: HasSling(state, self) or HasPunch(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
-                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
-                                  or HasHoop(state, self))
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self) or HasHoop(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
                     lambda state: CanHitMultiple(state, self))
     connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
-                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
-                                  or HasHoop(state, self))
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self) or HasHoop(state, self))
 
     # 2-3
     connect_regions(self, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
@@ -142,9 +130,7 @@ def set_noij_rules(self):
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
                     lambda state: CR_Inside(state, self))
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
-                    lambda state: CR_Inside(state, self) and ((CanSwim(state, self)
-                                                                 and CanHitMultiple(state, self))
-                                                                or HasFlyer(state, self)))
+                    lambda state: CR_Inside(state, self) and ((CanSwim(state, self) and CanHitMultiple(state, self)) or HasFlyer(state, self)))
     connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
                     lambda state: CR_Inside(state, self) and (CanHitMultiple(state, self) or (
                             CanSwim(state, self) and HasMobility(state, self))))
@@ -232,8 +218,7 @@ def set_noij_rules(self):
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
                     lambda state: CanHitOnce(state, self))
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
-                    lambda state: HasSling(state, self) or HasPunch(state, self) or (
-                            HasClub(state, self) and HasFlyer(state, self)))
+                    lambda state: HasSling(state, self) or HasPunch(state, self) or (HasClub(state, self) and HasFlyer(state, self)))
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value, lambda state: NoRequirement())
@@ -297,8 +282,7 @@ def set_noij_rules(self):
     connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
                     lambda state: HasFlyer(state, self))
     connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
-                    lambda state: HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self))
-                                  or SuperFlyer(state, self))
+                    lambda state: HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self)) or SuperFlyer(state, self))
     connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
 
@@ -321,11 +305,9 @@ def set_noij_rules(self):
     connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
                     lambda state: WSW_ThirdRoom(state, self) and RCMonkey(state, self))
     connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
-                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
-                            HasSling(state, self) or HasHoop(state, self)))
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (HasSling(state, self) or HasHoop(state, self)))
     connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
-                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
-                            HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
 
     # 7-3
     connect_regions(self, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
@@ -381,37 +363,27 @@ def set_noij_rules(self):
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
-                    lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
-                                  or HasFlyer(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self)) or HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
                     lambda state: NoRequirement())
     connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
-                    lambda state: (CP_FrontSewer(state, self) or CP_BackSewer(state, self))
-                                  and HasRC(state, self))
+                    lambda state: (CP_FrontSewer(state, self) or CP_BackSewer(state, self)) and HasRC(state, self))
     connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
-                    lambda state: (CP_FrontSewer(state, self) and HasRC(state, self))
-                                  or CP_BackSewer(state, self))
+                    lambda state: (CP_FrontSewer(state, self) and HasRC(state, self)) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
-                    lambda state: ((CP_FrontSewer(state, self) or CP_BackSewer(state, self))
-                                   and HasRC(state, self)) or HasFlyer(state, self))
+                    lambda state: ((CP_FrontSewer(state, self) or CP_BackSewer(state, self)) and HasRC(state, self)) or HasFlyer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
                     lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
-                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
-                                  and CanDive(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self)) and CanDive(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
                     lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
-                    lambda state: (CP_FrontBarrels(state, self) and (CanSwim(state, self)
-                                                                       or HasFlyer(state, self)))
-                                  or CP_BackSewer(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) and (CanSwim(state, self) or HasFlyer(state, self))) or CP_BackSewer(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
-                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
-                                  and CanDive(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self)) and CanDive(state, self))
     connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
-                    lambda state: (CP_FrontBarrels(state, self) and (HasHoop(state, self)
-                                                                       or CanSwim(state, self))
-                                   and HasFlyer(state, self)) or CP_BackSewer(state, self))
+                    lambda state: (CP_FrontBarrels(state, self) and (HasHoop(state, self) or CanSwim(state, self)) and HasFlyer(state, self)) or CP_BackSewer(state, self))
 
     # 8-2
     connect_regions(self, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
@@ -558,20 +530,17 @@ def set_noij_rules(self):
         connect_regions(self, AERoom.W2L1Fish.value, AERoom.Coin8.value,
                         lambda state: (TJ_FishEntry(state, self)))
         connect_regions(self, AERoom.W2L1Tent.value, AERoom.Coin9.value,
-                        lambda state: (TJ_FishEntry(state, self) and (CanHitMultiple(state, self))) or (
-                                (TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
+                        lambda state: (TJ_FishEntry(state, self) and (CanHitMultiple(state, self))) or ((TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
         # 2-2
         connect_regions(self, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
         connect_regions(self, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
         connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
-                        lambda state: (HasHoop(state, self) and HasFlyer(state, self))
-                                      or HasRC(state, self) or HasPunch(state, self))
+                        lambda state: (HasHoop(state, self) and HasFlyer(state, self)) or HasRC(state, self) or HasPunch(state, self))
         connect_regions(self, AERoom.W2L2Water.value, AERoom.Coin14.value,
                         lambda state: CanDive(state, self) and CanHitOnce(state, self))
         # 2-3
         connect_regions(self, AERoom.W2L3Main.value, AERoom.Coin17.value,
-                        lambda state: CR_Inside(state, self)
-                                      and (CanSwim(state, self) or HasMobility(state, self)))
+                        lambda state: CR_Inside(state, self) and (CanSwim(state, self) or HasMobility(state, self)))
         # 3-1
         connect_regions(self, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, self))
 
@@ -631,27 +600,21 @@ def set_noij_rules(self):
 
         # 7-3
         connect_regions(self, AERoom.W7L3Outside.value, AERoom.Coin45.value,
-                        lambda state: HasClub(state, self) or HasSling(state, self) or HasHoop(state, self)
-                                      or HasFlyer(state, self) or HasPunch(state, self))
+                        lambda state: HasClub(state, self) or HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self) or HasPunch(state, self))
         connect_regions(self, AERoom.W7L3Castle.value, AERoom.Coin46.value,
                         lambda state: CC_5Monkeys(state, self))
         connect_regions(self, AERoom.W7L3Button.value, AERoom.Coin49.value,
                         lambda state: CC_ButtonRoom(state, self))
         connect_regions(self, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
-                        lambda state: CC_5Monkeys(state, self) or CC_WaterRoom(state, self)
-                                      or (HasHoop(state, self) and HasFlyer(state, self)))
+                        lambda state: CC_5Monkeys(state, self) or CC_WaterRoom(state, self) or (HasHoop(state, self) and HasFlyer(state, self)))
 
         # 8-1
         connect_regions(self, AERoom.W8L1Outside.value, AERoom.Coin53.value,
-                        lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
-                                      or HasFlyer(state, self))
+                        lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self)) or HasFlyer(state, self))
         connect_regions(self, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
-                        lambda state: (CP_FrontSewer(state, self) and (
-                                HasRC(state, self) or SuperFlyer(state, self)))
-                                      or (CP_BackSewer(state, self) and HasRC(state, self)))
+                        lambda state: (CP_FrontSewer(state, self) and (HasRC(state, self) or SuperFlyer(state, self))) or (CP_BackSewer(state, self) and HasRC(state, self)))
         connect_regions(self, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
-                        lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
-                                      and HasFlyer(state, self))
+                        lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self)) and HasFlyer(state, self))
 
         # 8-2
         connect_regions(self, AERoom.W8L2RC.value, AERoom.Coin58.value,

--- a/worlds/apeescape/RulesNoIJ.py
+++ b/worlds/apeescape/RulesNoIJ.py
@@ -765,11 +765,11 @@ def WSW_FourthRoom(state, world):
 
 
 def CC_5Monkeys(state, world):
-    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasPunch(state, world))
+    return HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world) or HasPunch(state, world)
 
 
 def CC_WaterRoom(state, world):
-    return ((CanHitMultiple(state, world) and HasNet(state, world)) or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world))) or (HasFlyer(state, world) or HasHoop(state, world)) or SuperFlyer(state, world))
+    return (CanHitMultiple(state, world) and HasNet(state, world)) or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world))) or (HasFlyer(state, world) or HasHoop(state, world)) or SuperFlyer(state, world)
 
 
 def CC_ButtonRoom(state, world):
@@ -794,7 +794,7 @@ def SF_CarRoom(state, world):
 
 
 def SF_MechRoom(state, world):
-    return ((HasHoop(state, world) and HasFlyer(state, world)) or (HasClub(state, world) and (HasSling(state, world) or HasRC(state, world))) or HasPunch(state, world) or SuperFlyer(state, world))
+    return (HasHoop(state, world) and HasFlyer(state, world)) or (HasClub(state, world) and (HasSling(state, world) or HasRC(state, world))) or HasPunch(state, world) or SuperFlyer(state, world)
 
 
 def TVT_HitButton(state, world):
@@ -838,7 +838,7 @@ def MM_SpaceMonkeys(state, world):
 
 
 def MM_FinalBoss(state, world):
-    return ((MM_DoubleDoor(state, world) and HasSling(state, world) and HasFlyer(state, world)) or (MM_UFODoor(state, world) and SuperFlyer(state, world)))
+    return (MM_DoubleDoor(state, world) and HasSling(state, world) and HasFlyer(state, world)) or (MM_UFODoor(state, world) and SuperFlyer(state, world))
 
 
 def HasClub(state, world):

--- a/worlds/apeescape/RulesNoIJ.py
+++ b/worlds/apeescape/RulesNoIJ.py
@@ -789,8 +789,7 @@ def CP_BackSewer(state, world):
 
 
 def SF_CarRoom(state, world):
-    return (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world) or HasPunch(
-        state, world)
+    return (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world) or HasPunch(state, world)
 
 
 def SF_MechRoom(state, world):

--- a/worlds/apeescape/RulesNoIJ.py
+++ b/worlds/apeescape/RulesNoIJ.py
@@ -1,882 +1,890 @@
-from worlds.apeescape import location_table
-from worlds.generic.Rules import add_rule, set_rule, forbid_item
-from BaseClasses import LocationProgressType
 from .Regions import connect_regions
-from .Options import SuperFlyerOption
 from .Strings import AEItem, AEWorld, AERoom
 
 
-class NoIJ():
-    def set_rules(self, world, player: int, coins: bool):
+def set_noij_rules(self):
+    # Worlds
+    connect_regions(self, "Menu", AEWorld.W1.value, lambda state: NoRequirement())
+    connect_regions(self, "Menu", AEWorld.W2.value, lambda state: Keys(state, self, 1))
+    connect_regions(self, "Menu", AEWorld.W3.value,
+                    lambda state: CanSwim(state, self) and Keys(state, self, 2))
+    connect_regions(self, "Menu", AEWorld.W4.value, lambda state: Keys(state, self, 2))
+    connect_regions(self, "Menu", AEWorld.W5.value, lambda state: Keys(state, self, 3))
+    connect_regions(self, "Menu", AEWorld.W6.value,
+                    lambda state: HasFlyer(state, self) and Keys(state, self, 4))
+    connect_regions(self, "Menu", AEWorld.W7.value, lambda state: Keys(state, self, 4))
+    connect_regions(self, "Menu", AEWorld.W8.value, lambda state: Keys(state, self, 5))
+    connect_regions(self, "Menu", AEWorld.W9.value, lambda state: Keys(state, self, 6))
 
-        # Worlds
-        connect_regions(world, player, "Menu", AEWorld.W1.value, lambda state: NoRequirement())
-        connect_regions(world, player, "Menu", AEWorld.W2.value, lambda state: Keys(state, player, 1))
-        connect_regions(world, player, "Menu", AEWorld.W3.value,
-                        lambda state: CanSwim(state, player) and Keys(state, player, 2))
-        connect_regions(world, player, "Menu", AEWorld.W4.value, lambda state: Keys(state, player, 2))
-        connect_regions(world, player, "Menu", AEWorld.W5.value, lambda state: Keys(state, player, 3))
-        connect_regions(world, player, "Menu", AEWorld.W6.value,
-                        lambda state: HasFlyer(state, player) and Keys(state, player, 4))
-        connect_regions(world, player, "Menu", AEWorld.W7.value, lambda state: Keys(state, player, 4))
-        connect_regions(world, player, "Menu", AEWorld.W8.value, lambda state: Keys(state, player, 5))
-        connect_regions(world, player, "Menu", AEWorld.W9.value, lambda state: Keys(state, player, 6))
+    if self.options.goal == "second":
+        connect_regions(self, "Menu", AERoom.W9L2Boss.value,
+                        lambda state: Keys(state, self, 6) and HasSling(state, self)
+                                      and HasHoop(state, self) and HasFlyer(state, self)
+                                      and CanHitMultiple(state, self) and HasRC(state, self))
 
-        if world.goal[player].value == 0x01:
-            connect_regions(world, player, "Menu", AERoom.W9L2Boss.value,
-                            lambda state: Keys(state, player, 6) and HasSling(state, player) and HasHoop(state, player)
-                                          and HasFlyer(state, player) and CanHitMultiple(state, player)
-                                          and HasRC(state, player))
+    # 1-1
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
 
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Noonan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Jorjy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1Nati.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value, lambda state: NoRequirement())
+
+    # 1-2
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L2Main.value, lambda state: True)
+
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Shay.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2DrMonk.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Grunt.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Ahchoo.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Gornif.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L2Main.value, AERoom.W1L2Tyrone.value, lambda state: NoRequirement())
+
+    # 1-3
+    connect_regions(self, AEWorld.W1.value, AERoom.W1L3Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Volcano.value, lambda state: True)
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Triceratops.value,
+                    lambda state: HasSling(state, self))
+
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Scotty.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Coco.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3JThomas.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W1L3Entry.value, AERoom.W1L3Moggan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Volcano.value, AERoom.W1L3Barney.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Volcano.value, AERoom.W1L3Mattie.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W1L3Triceratops.value, AERoom.W1L3Rocky.value,
+                    lambda state: HasSling(state, self))
+
+    # 2-1
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L1Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Mushroom.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Fish.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Tent.value, lambda state: True)
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Boulder.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Marquez.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1Livinston.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W2L1Entry.value, AERoom.W2L1George.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Gonzo.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Zanzibar.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
+                    lambda state: TJ_Mushroom(state, self))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
+                    lambda state: TJ_FishEntry(state, self) and (
+                            HasSling(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
+                    lambda state: TJ_FishEntry(state, self))
+    connect_regions(self, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Stoddy.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Mitong.value,
+                    lambda state: (TJ_FishEntry(state, self) and CanHitMultiple(state, self)) or (
+                            TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self)))
+    connect_regions(self, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
+                    lambda state: ((TJ_FishEntry(state, self) or (TJ_UFOEntry(state, self)
+                                                                    and TJ_UFOCliff(state, self)))
+                                   and CanHitMultiple(state, self)))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value,
+                    lambda state: (TJ_UFOEntry(state, self) or (TJ_FishEntry(state, self))
+                                   and CanHitMultiple(state, self)))
+    connect_regions(self, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value,
+                    lambda state: ((TJ_UFOEntry(state, self) and TJ_UFOCliff(state, self))
+                                   or (TJ_FishEntry(state, self))
+                                   and CanHitMultiple(state, self)) and (HasClub(state, self)
+                                                                           or HasSling(state, self)
+                                                                           or HasFlyer(state, self)))
+
+    # 2-2
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Fan.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Obelisk.value, lambda state: True)
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Water.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Kyle.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Stan.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Kenny.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Cratman.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Outside.value, AERoom.W2L2Mooshy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Fan.value, AERoom.W2L2Nuzzy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Fan.value, AERoom.W2L2Mav.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Papou.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Trance.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
+                    lambda state: HasSling(state, self) or HasPunch(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
+                                  or HasHoop(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
+                    lambda state: CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
+                    lambda state: (CanSwim(state, self) and CanHitOnce(state, self)) or HasSling(state, self)
+                                  or HasHoop(state, self))
+
+    # 2-3
+    connect_regions(self, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Side.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Main.value, lambda state: True)
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Pillar.value, lambda state: True)
+
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Bazzle.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L3Outside.value, AERoom.W2L3Freeto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W2L3Side.value, AERoom.W2L3Troopa.value,
+                    lambda state: (HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
+                    lambda state: CR_Inside(state, self))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
+                    lambda state: CR_Inside(state, self) and ((CanSwim(state, self)
+                                                                 and CanHitMultiple(state, self))
+                                                                or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
+                    lambda state: CR_Inside(state, self) and (CanHitMultiple(state, self) or (
+                            CanSwim(state, self) and HasMobility(state, self))))
+    connect_regions(self, AERoom.W2L3Pillar.value, AERoom.W2L3Pally.value,
+                    lambda state: CR_Inside(state, self))
+    connect_regions(self, AERoom.W2L3Pillar.value, AERoom.W2L3Crash.value,
+                    lambda state: CR_Inside(state, self) and (RCMonkey(state, self) or SuperFlyer(state, self)))
+
+    # 4-1
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L1FirstRoom.value, lambda state: True)
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1SecondRoom.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1CoolBlue.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1Sandy.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1ShellE.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1FirstRoom.value, AERoom.W4L1Gidget.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Shaka.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Puka.value,
+                    lambda state: CanHitMultiple(state, self) or HasHoop(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1MaxMahalo.value,
+                    lambda state: HasHoop(state, self) or (HasSling(state, self) and HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.W4L1Moko.value,
+                    lambda state: HasFlyer(state, self))
+
+    # 4-2
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L2FirstRoom.value, lambda state: True)
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2SecondRoom.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Chip.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
+                    lambda state: (HasMobility(state, self)))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
+                    lambda state: CanDive(state, self) or (HasHoop(state, self) and HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value,
+                    lambda state: (HasMobility(state, self)))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2BongBong.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Jux.value,
+                    lambda state: CanSwim(state, self))
+    connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.W4L2Pickles.value,
+                    lambda state: CanSwim(state, self) and CanHitMultiple(state, self))
+
+    # 4-3
+    connect_regions(self, AEWorld.W4.value, AERoom.W4L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3Stomach.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Slide.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Slide.value, AERoom.W4L3Gallery.value, lambda state: True)
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Tentacle.value, lambda state: True)
+
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3TonTon.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Outside.value, AERoom.W4L3Stuw.value,
+                    lambda state: CanSwim(state, self) or CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Mars.value,
+                    lambda state: HasRC(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Murky.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W4L3Stomach.value, AERoom.W4L3Horke.value,
+                    lambda state: CanHitOnce(state, self) and (CanSwim(state, self) or HasFlyer(state, self)))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Howeerd.value,
+                    lambda state: DI_SecondHalf(state, self) and HasSling(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Robbin.value,
+                    lambda state: DI_SecondHalf(state, self) and HasSling(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Jakkee.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Frederic.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Gallery.value, AERoom.W4L3Baba.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+    connect_regions(self, AERoom.W4L3Tentacle.value, AERoom.W4L3Quirck.value,
+                    lambda state: DI_SecondHalf(state, self) and DI_Boulders(state, self))
+
+    # 5-1
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L1Main.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Popcicle.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
+                    lambda state: HasSling(state, self) or HasPunch(state, self) or (
+                            HasClub(state, self) and HasFlyer(state, self)))
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value, lambda state: NoRequirement())
+
+    # 5-2
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L2Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Water.value, lambda state: True)
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Caverns.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Storm.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Entry.value, AERoom.W5L2Qube.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Ranix.value,
+                    lambda state: CanSwim(state, self) or HasSling(state, self))
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sharpe.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Sticky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Water.value, AERoom.W5L2Droog.value,
+                    lambda state: CanDive(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Gash.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Kundra.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L2Caverns.value, AERoom.W5L2Shadow.value, lambda state: NoRequirement())
+
+    # 5-3
+    connect_regions(self, AEWorld.W5.value, AERoom.W5L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Spring.value, lambda state: True)
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Cave.value, lambda state: True)
+
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Punky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Ameego.value,
+                    lambda state: CanDive(state, self))
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Yoky.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Outside.value, AERoom.W5L3Jory.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Crank.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Claxter.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Spring.value, AERoom.W5L3Looza.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W5L3Cave.value, AERoom.W5L3Roti.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W5L3Cave.value, AERoom.W5L3Dissa.value,
+                    lambda state: CanHitOnce(state, self))
+
+    # 7-1
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Temple.value, lambda state: True)
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Well.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Taku.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Rocka.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Outside.value, AERoom.W7L1Wog.value,
+                    lambda state: HasClub(state, self) or HasSling(state, self) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Mayi.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Owyang.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Long.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Elly.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
+                    lambda state: HasSling(state, self) or (HasHoop(state, self) and HasFlyer(state, self))
+                                  or SuperFlyer(state, self))
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
+
+    # 7-2
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L2First.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Gong.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Middle.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Middle.value, AERoom.W7L2Course.value, lambda state: True)
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Barrel.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Minky.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2First.value, AERoom.W7L2Zobbro.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Xeeto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Moops.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Gong.value, AERoom.W7L2Zanabi.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L2Middle.value, AERoom.W7L2Doxs.value,
+                    lambda state: WSW_ThirdRoom(state, self))
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Buddha.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self))
+    connect_regions(self, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
+                    lambda state: WSW_ThirdRoom(state, self) and RCMonkey(state, self))
+    connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
+                            HasSling(state, self) or HasHoop(state, self)))
+    connect_regions(self, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
+                    lambda state: WSW_ThirdRoom(state, self) and WSW_FourthRoom(state, self) and (
+                            HasSling(state, self) or HasHoop(state, self) or HasFlyer(state, self)))
+
+    # 7-3
+    connect_regions(self, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Castle.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Basement.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Button.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Elevator.value, lambda state: True)
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Bell.value, lambda state: True)
+
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Robart.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Igor.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Naners.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Neeners.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Outside.value, AERoom.W7L3Charles.value,
+                    lambda state: HasPunch(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Gustav.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Wilhelm.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3Emmanuel.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Castle.value, AERoom.W7L3SirCutty.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Calligan.value,
+                    lambda state: CC_WaterRoom(state, self) and (
+                            CanDive(state, self) or HasPunch(state, self)))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Castalist.value,
+                    lambda state: CC_WaterRoom(state, self) and CanDive(state, self))
+    connect_regions(self, AERoom.W7L3Basement.value, AERoom.W7L3Deveneom.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Button.value, AERoom.W7L3Astur.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Button.value, AERoom.W7L3Kilserack.value,
+                    lambda state: CC_ButtonRoom(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Ringo.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Densil.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Elevator.value, AERoom.W7L3Figero.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Fej.value,
+                    lambda state: CC_5Monkeys(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Joey.value,
+                    lambda state: HasMobility(state, self))
+    connect_regions(self, AERoom.W7L3Bell.value, AERoom.W7L3Donqui.value, lambda state: NoRequirement())
+
+    # 8-1
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Sewers.value, lambda state: True)
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Barrel.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
+                    lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
+                                  or HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
+                    lambda state: (CP_FrontSewer(state, self) or CP_BackSewer(state, self))
+                                  and HasRC(state, self))
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
+                    lambda state: (CP_FrontSewer(state, self) and HasRC(state, self))
+                                  or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
+                    lambda state: ((CP_FrontSewer(state, self) or CP_BackSewer(state, self))
+                                   and HasRC(state, self)) or HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
+                    lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
+                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+                                  and CanDive(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
+                    lambda state: CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
+                    lambda state: (CP_FrontBarrels(state, self) and (CanSwim(state, self)
+                                                                       or HasFlyer(state, self)))
+                                  or CP_BackSewer(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
+                    lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+                                  and CanDive(state, self))
+    connect_regions(self, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
+                    lambda state: (CP_FrontBarrels(state, self) and (HasHoop(state, self)
+                                                                       or CanSwim(state, self))
+                                   and HasFlyer(state, self)) or CP_BackSewer(state, self))
+
+    # 8-2
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2Factory.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2RC.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Mech.value, AERoom.W8L2Lava.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Conveyor.value, lambda state: True)
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2Mech.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2BigShow.value,
+                    lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L2Outside.value, AERoom.W8L2Dreos.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L2Factory.value, AERoom.W8L2Reznor.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2RC.value, AERoom.W8L2Urkel.value,
+                    lambda state: SF_CarRoom(state, self) or HasSling(state, self) or SuperFlyer(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2VanillaS.value,
+                    lambda state: SF_MechRoom(state, self) and HasPunch(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Radd.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2Lava.value, AERoom.W8L2Shimbo.value,
+                    lambda state: SF_MechRoom(state, self) and RCMonkey(state, self))
+    connect_regions(self, AERoom.W8L2Conveyor.value, AERoom.W8L2Hurt.value,
+                    lambda state: SF_MechRoom(state, self) and CanHitMultiple(state, self))
+    connect_regions(self, AERoom.W8L2Conveyor.value, AERoom.W8L2String.value,
+                    lambda state: SF_MechRoom(state, self))
+    connect_regions(self, AERoom.W8L2Mech.value, AERoom.W8L2Khamo.value,
+                    lambda state: SF_MechRoom(state, self) and CanHitMultiple(state, self))
+
+    # 8-3
+    connect_regions(self, AEWorld.W8.value, AERoom.W8L3Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Water.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Outside.value, AERoom.W8L3Lobby.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Tank.value, lambda state: True)
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Fan.value, lambda state: True)
+
+    connect_regions(self, AERoom.W8L3Outside.value, AERoom.W8L3Fredo.value,
+                    lambda state: HasPunch(state, self))
+    connect_regions(self, AERoom.W8L3Water.value, AERoom.W8L3Charlee.value,
+                    lambda state: TVT_HitButton(state, self))
+    connect_regions(self, AERoom.W8L3Water.value, AERoom.W8L3Mach3.value,
+                    lambda state: TVT_HitButton(state, self))
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Tortuss.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W8L3Lobby.value, AERoom.W8L3Manic.value,
+                    lambda state: HasFlyer(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Ruptdis.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Eighty7.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Tank.value, AERoom.W8L3Danio.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Roosta.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Tellis.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Whack.value,
+                    lambda state: TVT_TankRoom(state, self))
+    connect_regions(self, AERoom.W8L3Fan.value, AERoom.W8L3Frostee.value,
+                    lambda state: TVT_TankRoom(state, self))
+
+    # 9-1
+    connect_regions(self, AEWorld.W9.value, AERoom.W9L1Entry.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Haunted.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Haunted.value, AERoom.W9L1Coffin.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Natalie.value,
+                    lambda state: MM_Natalie(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Professor.value,
+                    lambda state: MM_Professor(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Jake.value,
+                    lambda state: MM_Jake(state, self))
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Western.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Crater.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Crater.value, AERoom.W9L1Outside.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Castle.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Climb1.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Climb2.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Head.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Side.value, lambda state: True)
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Boss.value,
+                    lambda state: MM_FinalBoss(state, self))
+
+    connect_regions(self, AERoom.W9L1Entry.value, AERoom.W9L1Goopo.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Haunted.value, AERoom.W9L1Porto.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Slam.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Junk.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Coffin.value, AERoom.W9L1Crib.value,
+                    lambda state: CanHitOnce(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Nak.value,
+                    lambda state: HasSling(state, self) or HasHoop(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Cloy.value, lambda state: NoRequirement())
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Shaw.value,
+                    lambda state: HasSling(state, self) or HasHoop(state, self))
+    connect_regions(self, AERoom.W9L1Western.value, AERoom.W9L1Flea.value,
+                    lambda state: HasSling(state, self) or HasHoop(state, self))
+    connect_regions(self, AERoom.W9L1Crater.value, AERoom.W9L1Schafette.value,
+                    lambda state: MM_SHA(state, self) and HasFlyer(state, self))
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Donovan.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Outside.value, AERoom.W9L1Laura.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Uribe.value,
+                    lambda state: MM_UFODoor(state, self) and HasPunch(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Gordo.value,
+                    lambda state: MM_UFODoor(state, self) and (HasFlyer(state, self) or HasRC(state, self)))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Raeski.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Castle.value, AERoom.W9L1Poopie.value,
+                    lambda state: MM_UFODoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Teacup.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb1.value, AERoom.W9L1Shine.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Climb2.value, AERoom.W9L1Wrench.value,
+                    lambda state: MM_SpaceMonkeys(state, self))
+    connect_regions(self, AERoom.W9L1Climb2.value, AERoom.W9L1Bronson.value,
+                    lambda state: MM_SpaceMonkeys(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Bungee.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Carro.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Head.value, AERoom.W9L1Carlito.value,
+                    lambda state: MM_DoubleDoor(state, self))
+    connect_regions(self, AERoom.W9L1Side.value, AERoom.W9L1BG.value,
+                    lambda state: MM_SHA(state, self) and (HasSling(state, self) or HasFlyer(state, self)))
+
+    self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player, 1)
+
+    if self.options.coin == "true":
+        # Coins
         # 1-1
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L1Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Noonan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Jorjy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1Nati.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L1Main.value, AERoom.W1L1TrayC.value, lambda state: NoRequirement())
-
+        connect_regions(self, AERoom.W1L1Main.value, AERoom.Coin1.value, lambda state: NoRequirement())
         # 1-2
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L2Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Shay.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2DrMonk.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Grunt.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Ahchoo.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Gornif.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L2Main.value, AERoom.W1L2Tyrone.value, lambda state: NoRequirement())
-
+        connect_regions(self, AERoom.W1L2Main.value, AERoom.Coin2.value,
+                        lambda state: CanDive(state, self))
         # 1-3
-        connect_regions(world, player, AEWorld.W1.value, AERoom.W1L3Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Volcano.value, lambda state: True)
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Triceratops.value,
-                        lambda state: HasSling(state, player))
-
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Scotty.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Coco.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3JThomas.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.W1L3Moggan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Volcano.value, AERoom.W1L3Barney.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Volcano.value, AERoom.W1L3Mattie.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W1L3Triceratops.value, AERoom.W1L3Rocky.value,
-                        lambda state: HasSling(state, player))
-
+        connect_regions(self, AERoom.W1L3Entry.value, AERoom.Coin3.value, lambda state: NoRequirement())
         # 2-1
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L1Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Mushroom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Fish.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Tent.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Boulder.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Marquez.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1Livinston.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.W2L1George.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Gonzo.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Zanzibar.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.W2L1Alphonse.value,
-                        lambda state: TJ_Mushroom(state, player))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Maki.value,
-                        lambda state: TJ_FishEntry(state, player) and (
-                                HasSling(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Herb.value,
-                        lambda state: TJ_FishEntry(state, player))
-        connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.W2L1Dilweed.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Stoddy.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Mitong.value,
-                        lambda state: (TJ_FishEntry(state, player) and CanHitMultiple(state, player)) or (
-                                TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player)))
-        connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.W2L1Nasus.value,
-                        lambda state: ((TJ_FishEntry(state, player) or (TJ_UFOEntry(state, player)
-                                                                        and TJ_UFOCliff(state, player)))
-                                       and CanHitMultiple(state, player)))
-        connect_regions(world, player, AERoom.W2L1Boulder.value, AERoom.W2L1Elehcim.value,
-                        lambda state: (TJ_UFOEntry(state, player) or (TJ_FishEntry(state, player))
-                                       and CanHitMultiple(state, player)))
-        connect_regions(world, player, AERoom.W2L1Boulder.value, AERoom.W2L1Selur.value,
-                        lambda state: ((TJ_UFOEntry(state, player) and TJ_UFOCliff(state, player))
-                                       or (TJ_FishEntry(state, player))
-                                       and CanHitMultiple(state, player)) and (HasClub(state, player)
-                                                                               or HasSling(state, player)
-                                                                               or HasFlyer(state, player)))
-
+        connect_regions(self, AERoom.W2L1Entry.value, AERoom.Coin6.value,
+                        lambda state: HasMobility(state, self))
+        connect_regions(self, AERoom.W2L1Mushroom.value, AERoom.Coin7.value,
+                        lambda state: TJ_Mushroom(state, self))
+        connect_regions(self, AERoom.W2L1Fish.value, AERoom.Coin8.value,
+                        lambda state: (TJ_FishEntry(state, self)))
+        connect_regions(self, AERoom.W2L1Tent.value, AERoom.Coin9.value,
+                        lambda state: (TJ_FishEntry(state, self) and (CanHitMultiple(state, self))) or (
+                                (TJ_UFOEntry(state, self)) and (TJ_UFOCliff(state, self))))
         # 2-2
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L2Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Fan.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Obelisk.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Water.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Kyle.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Stan.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Kenny.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Cratman.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.W2L2Mooshy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.W2L2Nuzzy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.W2L2Mav.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Papou.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Trance.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.W2L2Bernt.value,
-                        lambda state: HasSling(state, player) or HasPunch(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Runt.value,
-                        lambda state: (CanSwim(state, player) and CanHitOnce(state, player)) or HasSling(state,player)
-                        or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Hoolah.value,
-                        lambda state: CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W2L2Water.value, AERoom.W2L2Chino.value,
-                        lambda state: (CanSwim(state, player) and CanHitOnce(state, player)) or HasSling(state,player)
-                        or HasHoop(state, player))
-
+        connect_regions(self, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
+                        lambda state: (HasHoop(state, self) and HasFlyer(state, self))
+                                      or HasRC(state, self) or HasPunch(state, self))
+        connect_regions(self, AERoom.W2L2Water.value, AERoom.Coin14.value,
+                        lambda state: CanDive(state, self) and CanHitOnce(state, self))
         # 2-3
-        connect_regions(world, player, AEWorld.W2.value, AERoom.W2L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Side.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Main.value, lambda state: True)
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Pillar.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Bazzle.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L3Outside.value, AERoom.W2L3Freeto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W2L3Side.value, AERoom.W2L3Troopa.value,
-                        lambda state: (HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Stymie.value,
-                        lambda state: CR_Inside(state, player))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Spanky.value,
-                        lambda state: CR_Inside(state, player) and ((CanSwim(state, player)
-                                                                     and CanHitMultiple(state, player))
-                                                                    or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W2L3Main.value, AERoom.W2L3Jesta.value,
-                        lambda state: CR_Inside(state, player) and (CanHitMultiple(state, player) or (
-                                CanSwim(state, player) and HasMobility(state, player))))
-        connect_regions(world, player, AERoom.W2L3Pillar.value, AERoom.W2L3Pally.value,
-                        lambda state: CR_Inside(state, player))
-        connect_regions(world, player, AERoom.W2L3Pillar.value, AERoom.W2L3Crash.value,
-                        lambda state: CR_Inside(state, player) and (RCMonkey(state, player) or SuperFlyer(state, player)))
+        connect_regions(self, AERoom.W2L3Main.value, AERoom.Coin17.value,
+                        lambda state: CR_Inside(state, self)
+                                      and (CanSwim(state, self) or HasMobility(state, self)))
+        # 3-1
+        connect_regions(self, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, self))
 
         # 4-1
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L1FirstRoom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1SecondRoom.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1CoolBlue.value,
+        connect_regions(self, AERoom.W4L1SecondRoom.value, AERoom.Coin21.value,
                         lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1Sandy.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1ShellE.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1FirstRoom.value, AERoom.W4L1Gidget.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Shaka.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Puka.value,
-                        lambda state: CanHitMultiple(state, player) or HasHoop(state, player) or HasFlyer(state,player))
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1MaxMahalo.value,
-                        lambda state: HasHoop(state, player) or (HasSling(state, player) and HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.W4L1Moko.value,
-                        lambda state: HasFlyer(state, player))
 
         # 4-2
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L2FirstRoom.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2SecondRoom.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Chip.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Oreo.value,
-                        lambda state: (HasMobility(state, player)))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Puddles.value,
-                        lambda state: CanDive(state, player) or (HasHoop(state, player) and HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L2FirstRoom.value, AERoom.W4L2Kalama.value,
-                        lambda state: (HasMobility(state, player)))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Iz.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2BongBong.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Jux.value,
-                        lambda state: CanSwim(state, player))
-        connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.W4L2Pickles.value,
-                        lambda state: CanSwim(state, player) and CanHitMultiple(state, player))
+        connect_regions(self, AERoom.W4L2SecondRoom.value, AERoom.Coin23.value,
+                        lambda state: CanDive(state, self) or (CanSwim(state, self) and HasRC(state, self)))
 
         # 4-3
-        connect_regions(world, player, AEWorld.W4.value, AERoom.W4L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3Stomach.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Slide.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Slide.value, AERoom.W4L3Gallery.value, lambda state: True)
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Tentacle.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3TonTon.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.W4L3Stuw.value,
-                        lambda state: CanSwim(state, player) or CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Mars.value,
-                        lambda state: HasRC(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Murky.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.W4L3Horke.value,
-                        lambda state: CanHitOnce(state, player) and (CanSwim(state, player) or HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Howeerd.value,
-                        lambda state: DI_SecondHalf(state, player) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Robbin.value,
-                        lambda state: DI_SecondHalf(state, player) and HasSling(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Jakkee.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Frederic.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Gallery.value, AERoom.W4L3Baba.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
-        connect_regions(world, player, AERoom.W4L3Tentacle.value, AERoom.W4L3Quirck.value,
-                        lambda state: DI_SecondHalf(state, player) and DI_Boulders(state, player))
+        connect_regions(self, AERoom.W4L3Outside.value, AERoom.Coin24.value,
+                        lambda state: CanSwim(state, self) or CanHitOnce(state, self))
+        connect_regions(self, AERoom.W4L3Stomach.value, AERoom.Coin25.value,
+                        lambda state: CanDive(state, self) and CanHitOnce(state, self))
+        connect_regions(self, AERoom.W4L3Slide.value, AERoom.Coin28.value,
+                        lambda state: (CanHitOnce(state, self)) or HasPunch(state, self))
+        # CanHitOnce and Net, if Net is shuffled.
 
         # 5-1
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L1Main.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Popcicle.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Iced.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Rickets.value,
-                        lambda state: HasSling(state, player) or HasPunch(state, player) or (
-                                HasClub(state, player) and HasFlyer(state, player)))
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Skeens.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Chilly.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L1Main.value, AERoom.W5L1Denggoy.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W5L1Main.value, AERoom.Coin29.value,
+                        lambda state: NoRequirement())
 
         # 5-2
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L2Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Water.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Caverns.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Storm.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.W5L2Qube.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Ranix.value,
-                        lambda state: CanSwim(state, player) or HasSling(state, player))
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Sharpe.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Sticky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Water.value, AERoom.W5L2Droog.value,
-                        lambda state: CanDive(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Gash.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Kundra.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.W5L2Shadow.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W5L2Entry.value, AERoom.Coin30.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W5L2Water.value, AERoom.Coin31.value,
+                        lambda state: CanDive(state, self))
+        connect_regions(self, AERoom.W5L2Caverns.value, AERoom.Coin32.value,
+                        lambda state: NoRequirement())
 
         # 5-3
-        connect_regions(world, player, AEWorld.W5.value, AERoom.W5L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Spring.value, lambda state: True)
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Cave.value, lambda state: True)
+        connect_regions(self, AERoom.W5L3Spring.value, AERoom.Coin34.value,
+                        lambda state: HasFlyer(state, self))
+        connect_regions(self, AERoom.W5L3Cave.value, AERoom.Coin35.value,
+                        lambda state: CanHitOnce(state, self))
 
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Punky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Ameego.value,
-                        lambda state: CanDive(state, player))
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Yoky.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Outside.value, AERoom.W5L3Jory.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Crank.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Claxter.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.W5L3Looza.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.W5L3Roti.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.W5L3Dissa.value,
-                        lambda state: CanHitOnce(state, player))
+        # 6-1
+        connect_regions(self, AEWorld.W6.value, AERoom.Coin36.value, lambda state: HasFlyer(state, self))
 
         # 7-1
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Temple.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Well.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Taku.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Rocka.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Maralea.value,
+        connect_regions(self, AERoom.W7L1Outside.value, AERoom.Coin37.value,
                         lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.W7L1Wog.value,
-                        lambda state: HasClub(state, player) or HasSling(state, player) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Mayi.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Owyang.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Long.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Elly.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.W7L1Chunky.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1Voti.value,
-                        lambda state: HasSling(state, player) or (HasHoop(state, player) and HasFlyer(state, player)) or SuperFlyer(state, player))
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1QuelTin.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L1Well.value, AERoom.W7L1Phaldo.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L1Temple.value, AERoom.Coin38.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L1Well.value, AERoom.Coin39.value,
+                        lambda state: HasFlyer(state, self))
 
         # 7-2
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L2First.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Gong.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Middle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Middle.value, AERoom.W7L2Course.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Barrel.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Minky.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2First.value, AERoom.W7L2Zobbro.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Xeeto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Moops.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.W7L2Zanabi.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L2Middle.value, AERoom.W7L2Doxs.value,
-                        lambda state: WSW_ThirdRoom(state, player))
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Buddha.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player))
-        connect_regions(world, player, AERoom.W7L2Course.value, AERoom.W7L2Fooey.value,
-                        lambda state: WSW_ThirdRoom(state, player) and RCMonkey(state, player))
-        connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.W7L2Kong.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player) and (
-                                HasSling(state, player) or HasHoop(state, player)))
-        connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.W7L2Phool.value,
-                        lambda state: WSW_ThirdRoom(state, player) and WSW_FourthRoom(state, player) and (
-                                HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player)))
+        connect_regions(self, AERoom.W7L2First.value, AERoom.Coin40.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L2Gong.value, AERoom.Coin41.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L2Barrel.value, AERoom.Coin43.value,
+                        lambda state: HasFlyer(state, self))
 
         # 7-3
-        connect_regions(world, player, AEWorld.W7.value, AERoom.W7L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Castle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Basement.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Button.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Elevator.value, lambda state: True)
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Bell.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Robart.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Igor.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Naners.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Neeners.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.W7L3Charles.value,
-                        lambda state: HasPunch(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Gustav.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Wilhelm.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3Emmanuel.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.W7L3SirCutty.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Calligan.value,
-                        lambda state: CC_WaterRoom(state, player) and (
-                                CanDive(state, player) or HasPunch(state, player)))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Castalist.value,
-                        lambda state: CC_WaterRoom(state, player) and CanDive(state, player))
-        connect_regions(world, player, AERoom.W7L3Basement.value, AERoom.W7L3Deveneom.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Button.value, AERoom.W7L3Astur.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Button.value, AERoom.W7L3Kilserack.value,
-                        lambda state: CC_ButtonRoom(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Ringo.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Densil.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.W7L3Figero.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Fej.value,
-                        lambda state: CC_5Monkeys(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Joey.value,
-                        lambda state: HasMobility(state, player))
-        connect_regions(world, player, AERoom.W7L3Bell.value, AERoom.W7L3Donqui.value, lambda state: NoRequirement())
+        connect_regions(self, AERoom.W7L3Outside.value, AERoom.Coin45.value,
+                        lambda state: HasClub(state, self) or HasSling(state, self) or HasHoop(state, self)
+                                      or HasFlyer(state, self) or HasPunch(state, self))
+        connect_regions(self, AERoom.W7L3Castle.value, AERoom.Coin46.value,
+                        lambda state: CC_5Monkeys(state, self))
+        connect_regions(self, AERoom.W7L3Button.value, AERoom.Coin49.value,
+                        lambda state: CC_ButtonRoom(state, self))
+        connect_regions(self, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
+                        lambda state: CC_5Monkeys(state, self) or CC_WaterRoom(state, self)
+                                      or (HasHoop(state, self) and HasFlyer(state, self)))
 
         # 8-1
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Sewers.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1Barrel.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Kaine.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Jaxx.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Gehry.value,
-                        lambda state: (CP_FrontBarrels(state, player) and CanDive(state, player))
-                                      or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.W8L1Alcatraz.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1Tino.value,
-                        lambda state: (CP_FrontSewer(state, player) or CP_BackSewer(state, player))
-                        and HasRC(state, player))
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1QBee.value,
-                        lambda state: (CP_FrontSewer(state, player) and HasRC(state, player))
-                        or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.W8L1McManic.value,
-                        lambda state: ((CP_FrontSewer(state, player) or CP_BackSewer(state, player))
-                                       and HasRC(state, player)) or HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Dywan.value,
-                        lambda state: CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1CKHutch.value,
-                        lambda state: (CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-                        and CanDive(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Winky.value,
-                        lambda state: CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1BLuv.value,
-                        lambda state: (CP_FrontBarrels(state, player) and (CanSwim(state, player)
-                                                                           or HasFlyer(state, player)))
-                        or CP_BackSewer(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Camper.value,
-                        lambda state: (CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-                        and CanDive(state, player))
-        connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.W8L1Huener.value,
-                        lambda state: (CP_FrontBarrels(state, player) and (HasHoop(state, player)
-                                                                           or CanSwim(state, player))
-                                       and HasFlyer(state, player)) or CP_BackSewer(state, player))
+        connect_regions(self, AERoom.W8L1Outside.value, AERoom.Coin53.value,
+                        lambda state: (CP_FrontBarrels(state, self) and CanDive(state, self))
+                                      or HasFlyer(state, self))
+        connect_regions(self, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
+                        lambda state: (CP_FrontSewer(state, self) and (
+                                HasRC(state, self) or SuperFlyer(state, self)))
+                                      or (CP_BackSewer(state, self) and HasRC(state, self)))
+        connect_regions(self, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
+                        lambda state: (CP_FrontBarrels(state, self) or CP_BackSewer(state, self))
+                                      and HasFlyer(state, self))
 
         # 8-2
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L2Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2Factory.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2RC.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Mech.value, AERoom.W8L2Lava.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Conveyor.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2Mech.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2BigShow.value,
-                        lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L2Outside.value, AERoom.W8L2Dreos.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L2Factory.value, AERoom.W8L2Reznor.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2RC.value, AERoom.W8L2Urkel.value,
-                        lambda state: SF_CarRoom(state, player) or HasSling(state, player) or SuperFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2VanillaS.value,
-                        lambda state: SF_MechRoom(state, player) and HasPunch(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Radd.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.W8L2Shimbo.value,
-                        lambda state: SF_MechRoom(state, player) and RCMonkey(state, player))
-        connect_regions(world, player, AERoom.W8L2Conveyor.value, AERoom.W8L2Hurt.value,
-                        lambda state: SF_MechRoom(state, player) and CanHitMultiple(state, player))
-        connect_regions(world, player, AERoom.W8L2Conveyor.value, AERoom.W8L2String.value,
-                        lambda state: SF_MechRoom(state, player))
-        connect_regions(world, player, AERoom.W8L2Mech.value, AERoom.W8L2Khamo.value,
-                        lambda state: SF_MechRoom(state, player) and CanHitMultiple(state, player))
+        connect_regions(self, AERoom.W8L2RC.value, AERoom.Coin58.value,
+                        lambda state: SF_CarRoom(state, self) or SuperFlyer(state, self))
+        connect_regions(self, AERoom.W8L2Lava.value, AERoom.Coin62.value,
+                        lambda state: SF_MechRoom(state, self))
 
         # 8-3
-        connect_regions(world, player, AEWorld.W8.value, AERoom.W8L3Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Water.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Outside.value, AERoom.W8L3Lobby.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Tank.value, lambda state: True)
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Fan.value, lambda state: True)
-
-        connect_regions(world, player, AERoom.W8L3Outside.value, AERoom.W8L3Fredo.value,
-                        lambda state: HasPunch(state, player))
-        connect_regions(world, player, AERoom.W8L3Water.value, AERoom.W8L3Charlee.value,
-                        lambda state: TVT_HitButton(state, player))
-        connect_regions(world, player, AERoom.W8L3Water.value, AERoom.W8L3Mach3.value,
-                        lambda state: TVT_HitButton(state, player))
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Tortuss.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W8L3Lobby.value, AERoom.W8L3Manic.value,
-                        lambda state: HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Ruptdis.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Eighty7.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.W8L3Danio.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Roosta.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Tellis.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Whack.value,
-                        lambda state: TVT_TankRoom(state, player))
-        connect_regions(world, player, AERoom.W8L3Fan.value, AERoom.W8L3Frostee.value,
-                        lambda state: TVT_TankRoom(state, player))
+        connect_regions(self, AERoom.W8L3Water.value, AERoom.Coin64.value,
+                        lambda state: HasFlyer(state, self))
+        connect_regions(self, AERoom.W8L3Tank.value, AERoom.Coin66.value,
+                        lambda state: TVT_TankRoom(state, self))
 
         # 9-1
-        connect_regions(world, player, AEWorld.W9.value, AERoom.W9L1Entry.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Haunted.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.W9L1Coffin.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Natalie.value,
-                        lambda state: MM_Natalie(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Professor.value,
-                        lambda state: MM_Professor(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Jake.value,
-                        lambda state: MM_Jake(state, player))
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Western.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Crater.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.W9L1Outside.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Castle.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Climb1.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Climb2.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Head.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Side.value, lambda state: True)
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Boss.value,
-                        lambda state: MM_FinalBoss(state, player))
-
-        connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.W9L1Goopo.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.W9L1Porto.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Slam.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Junk.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Coffin.value, AERoom.W9L1Crib.value,
-                        lambda state: CanHitOnce(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Nak.value,
-                        lambda state: HasSling(state, player) or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Cloy.value, lambda state: NoRequirement())
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Shaw.value,
-                        lambda state: HasSling(state, player) or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W9L1Western.value, AERoom.W9L1Flea.value,
-                        lambda state: HasSling(state, player) or HasHoop(state, player))
-        connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.W9L1Schafette.value,
-                        lambda state: MM_SHA(state, player) and HasFlyer(state, player))
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Donovan.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.W9L1Laura.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Uribe.value,
-                        lambda state: MM_UFODoor(state, player) and HasPunch(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Gordo.value,
-                        lambda state: MM_UFODoor(state, player) and (HasFlyer(state, player) or HasRC(state, player)))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Raeski.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.W9L1Poopie.value,
-                        lambda state: MM_UFODoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Teacup.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb1.value, AERoom.W9L1Shine.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.W9L1Wrench.value,
-                        lambda state: MM_SpaceMonkeys(state, player))
-        connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.W9L1Bronson.value,
-                        lambda state: MM_SpaceMonkeys(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Bungee.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Carro.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Head.value, AERoom.W9L1Carlito.value,
-                        lambda state: MM_DoubleDoor(state, player))
-        connect_regions(world, player, AERoom.W9L1Side.value, AERoom.W9L1BG.value,
-                        lambda state: MM_SHA(state, player) and (HasSling(state, player) or HasFlyer(state, player)))
-
-        world.completion_condition[player] = lambda state: state.has("Victory", player, 1)
-
-        if coins:
-            # Coins
-            # 1-1
-            connect_regions(world, player, AERoom.W1L1Main.value, AERoom.Coin1.value, lambda state: NoRequirement())
-            # 1-2
-            connect_regions(world, player, AERoom.W1L2Main.value, AERoom.Coin2.value,
-                            lambda state: CanDive(state, player))
-            # 1-3
-            connect_regions(world, player, AERoom.W1L3Entry.value, AERoom.Coin3.value, lambda state: NoRequirement())
-            # 2-1
-            connect_regions(world, player, AERoom.W2L1Entry.value, AERoom.Coin6.value,
-                            lambda state: HasMobility(state, player))
-            connect_regions(world, player, AERoom.W2L1Mushroom.value, AERoom.Coin7.value,
-                            lambda state: TJ_Mushroom(state, player))
-            connect_regions(world, player, AERoom.W2L1Fish.value, AERoom.Coin8.value,
-                            lambda state: (TJ_FishEntry(state, player)))
-            connect_regions(world, player, AERoom.W2L1Tent.value, AERoom.Coin9.value,
-                            lambda state: ((TJ_FishEntry(state, player)) and (CanHitMultiple(state, player))) or (
-                                    (TJ_UFOEntry(state, player)) and (TJ_UFOCliff(state, player))))
-            # 2-2
-            connect_regions(world, player, AERoom.W2L2Outside.value, AERoom.Coin11.value, lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W2L2Fan.value, AERoom.Coin12.value, lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W2L2Obelisk.value, AERoom.Coin13.value,
-                            lambda state: (HasHoop(state, player) and HasFlyer(state, player)) or
-                                    HasRC(state, player) or HasPunch(state, player))
-            connect_regions(world, player, AERoom.W2L2Water.value, AERoom.Coin14.value,
-                            lambda state: CanDive(state, player) and CanHitOnce(state, player))
-            # 2-3
-            connect_regions(world, player, AERoom.W2L3Main.value, AERoom.Coin17.value,
-                            lambda state: CR_Inside(state, player) and
-                                    (CanSwim(state, player) or HasMobility(state, player)))
-            # 3-1
-            connect_regions(world, player, AEWorld.W3.value, AERoom.Coin19.value, lambda state: CanSwim(state, player))
-
-            # 4-1
-            connect_regions(world, player, AERoom.W4L1SecondRoom.value, AERoom.Coin21.value,
-                            lambda state: NoRequirement())
-
-            # 4-2
-            connect_regions(world, player, AERoom.W4L2SecondRoom.value, AERoom.Coin23.value,
-                            lambda state: CanDive(state, player) or (CanSwim(state, player) and HasRC(state, player)))
-
-            # 4-3
-            connect_regions(world, player, AERoom.W4L3Outside.value, AERoom.Coin24.value,
-                            lambda state: CanSwim(state, player) or CanHitOnce(state, player))
-            connect_regions(world, player, AERoom.W4L3Stomach.value, AERoom.Coin25.value,
-                            lambda state: CanDive(state, player) and CanHitOnce(state, player))
-            connect_regions(world, player, AERoom.W4L3Slide.value, AERoom.Coin28.value,
-                            lambda state: (CanHitOnce(state, player)) or HasPunch(state, player))
-            #CanHitOnce and Net, if Net is shuffled.
-
-            # 5-1
-            connect_regions(world, player, AERoom.W5L1Main.value, AERoom.Coin29.value,
-                            lambda state: NoRequirement())
-
-            # 5-2
-            connect_regions(world, player, AERoom.W5L2Entry.value, AERoom.Coin30.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W5L2Water.value, AERoom.Coin31.value,
-                            lambda state: CanDive(state, player))
-            connect_regions(world, player, AERoom.W5L2Caverns.value, AERoom.Coin32.value,
-                            lambda state: NoRequirement())
-
-            # 5-3
-            connect_regions(world, player, AERoom.W5L3Spring.value, AERoom.Coin34.value,
-                            lambda state: HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W5L3Cave.value, AERoom.Coin35.value,
-                            lambda state: CanHitOnce(state, player))
-
-            # 6-1
-            connect_regions(world, player, AEWorld.W6.value, AERoom.Coin36.value, lambda state: HasFlyer(state, player))
-
-            # 7-1
-            connect_regions(world, player, AERoom.W7L1Outside.value, AERoom.Coin37.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L1Temple.value, AERoom.Coin38.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L1Well.value, AERoom.Coin39.value,
-                            lambda state: HasFlyer(state, player))
-
-            # 7-2
-            connect_regions(world, player, AERoom.W7L2First.value, AERoom.Coin40.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L2Gong.value, AERoom.Coin41.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W7L2Barrel.value, AERoom.Coin43.value,
-                            lambda state: HasFlyer(state, player))
-
-            # 7-3
-            connect_regions(world, player, AERoom.W7L3Outside.value, AERoom.Coin45.value,
-                            lambda state: HasClub(state, player) or HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player) or HasPunch(state, player))
-            connect_regions(world, player, AERoom.W7L3Castle.value, AERoom.Coin46.value,
-                            lambda state: CC_5Monkeys(state, player))
-            connect_regions(world, player, AERoom.W7L3Button.value, AERoom.Coin49.value,
-                            lambda state: CC_ButtonRoom(state, player))
-            connect_regions(world, player, AERoom.W7L3Elevator.value, AERoom.Coin50.value,
-                            lambda state: CC_5Monkeys(state, player) or CC_WaterRoom(state, player) or
-                                    (HasHoop(state, player) and HasFlyer(state, player)))
-
-            # 8-1
-            connect_regions(world, player, AERoom.W8L1Outside.value, AERoom.Coin53.value,
-                            lambda state: (CP_FrontBarrels(state, player) and CanDive(state, player)) or
-                                    HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L1Sewers.value, AERoom.Coin54.value,
-                            lambda state: (CP_FrontSewer(state, player) and (HasRC(state, player) or SuperFlyer(state, player))) or (CP_BackSewer(state, player) and HasRC(state, player)))
-            connect_regions(world, player, AERoom.W8L1Barrel.value, AERoom.Coin55.value,
-                            lambda state: (CP_FrontBarrels(state, player) or CP_BackSewer(state, player))
-                                    and HasFlyer(state, player))
-
-            # 8-2
-            connect_regions(world, player, AERoom.W8L2RC.value, AERoom.Coin58.value,
-                            lambda state: SF_CarRoom(state, player) or SuperFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L2Lava.value, AERoom.Coin62.value,
-                            lambda state: SF_MechRoom(state, player))
-
-            # 8-3
-            connect_regions(world, player, AERoom.W8L3Water.value, AERoom.Coin64.value,
-                            lambda state: HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W8L3Tank.value, AERoom.Coin66.value,
-                            lambda state: TVT_TankRoom(state, player))
-
-            # 9-1
-            connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.Coin73.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Entry.value, AERoom.Coin74.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Haunted.value, AERoom.Coin75.value,
-                            lambda state: HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W9L1Western.value, AERoom.Coin77.value,
-                            lambda state: NoRequirement())
-            connect_regions(world, player, AERoom.W9L1Crater.value, AERoom.Coin78.value,
-                            lambda state: MM_SHA(state, player) and HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W9L1Outside.value, AERoom.Coin79.value,
-                            lambda state: MM_SHA(state, player))
-            connect_regions(world, player, AERoom.W9L1Castle.value, AERoom.Coin80.value,
-                            lambda state: MM_UFODoor(state, player))
-            connect_regions(world, player, AERoom.W9L1Head.value, AERoom.Coin84.value,
-                            lambda state: MM_DoubleDoor(state, player))
-            connect_regions(world, player, AERoom.W9L1Side.value, AERoom.Coin85.value,
-                            lambda state: MM_SHA(state, player) and HasFlyer(state, player))
-            connect_regions(world, player, AERoom.W9L1Climb2.value, AERoom.Coin82.value,
-                            lambda state: MM_SpaceMonkeys(state, player))
+        connect_regions(self, AERoom.W9L1Entry.value, AERoom.Coin73.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Entry.value, AERoom.Coin74.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Haunted.value, AERoom.Coin75.value,
+                        lambda state: HasFlyer(state, self))
+        connect_regions(self, AERoom.W9L1Western.value, AERoom.Coin77.value,
+                        lambda state: NoRequirement())
+        connect_regions(self, AERoom.W9L1Crater.value, AERoom.Coin78.value,
+                        lambda state: MM_SHA(state, self) and HasFlyer(state, self))
+        connect_regions(self, AERoom.W9L1Outside.value, AERoom.Coin79.value,
+                        lambda state: MM_SHA(state, self))
+        connect_regions(self, AERoom.W9L1Castle.value, AERoom.Coin80.value,
+                        lambda state: MM_UFODoor(state, self))
+        connect_regions(self, AERoom.W9L1Head.value, AERoom.Coin84.value,
+                        lambda state: MM_DoubleDoor(state, self))
+        connect_regions(self, AERoom.W9L1Side.value, AERoom.Coin85.value,
+                        lambda state: MM_SHA(state, self) and HasFlyer(state, self))
+        connect_regions(self, AERoom.W9L1Climb2.value, AERoom.Coin82.value,
+                        lambda state: MM_SpaceMonkeys(state, self))
 
 
-def Keys(state, player, count):
-    return state.has(AEItem.Key.value, player, count)
+def Keys(state, world, count):
+    return state.has(AEItem.Key.value, world.player, count)
 
 
 def NoRequirement():
     return True
 
 
-def CanHitOnce(state, player):
-    return HasClub(state, player) or HasRadar(state, player) or HasSling(state, player) or HasHoop(state,
-                                                                                                   player) or HasFlyer(
-        state, player) or HasRC(state, player) or HasPunch(state, player)
+def CanHitOnce(state, world):
+    return HasClub(state, world) or HasRadar(state, world) or HasSling(state, world) or HasHoop(
+        state, world) or HasFlyer(
+        state, world) or HasRC(state, world) or HasPunch(state, world)
 
 
-def CanHitMultiple(state, player):
-    return HasClub(state, player) or HasSling(state, player) or HasHoop(state, player) or HasPunch(state, player)
+def CanHitMultiple(state, world):
+    return HasClub(state, world) or HasSling(state, world) or HasHoop(state, world) or HasPunch(
+        state, world)
 
 
-def HasMobility(state, player):
-    return HasHoop(state, player) or HasFlyer(state, player)
+def HasMobility(state, world):
+    return HasHoop(state, world) or HasFlyer(state, world)
 
 
-def RCMonkey(state, player):
-    return HasSling(state, player) or HasRC(state, player)
+def RCMonkey(state, world):
+    return HasSling(state, world) or HasRC(state, world)
 
 
-def CanSwim(state, player):
-    return HasWaterNet(state, player)
+def CanSwim(state, world):
+    return HasWaterNet(state, world)
 
 
-def CanDive(state, player):
-    return HasWaterNet(state, player)
+def CanDive(state, world):
+    return HasWaterNet(state, world)
 
 
-def CanWaterCatch(state, player):
-    return HasWaterNet(state, player)
+def CanWaterCatch(state, world):
+    return HasWaterNet(state, world)
 
 
-def SuperFlyer(state, player):
-    return HasFlyer(state, player) and (HasNet(state, player) or HasClub(state, player) or HasSling(state, player) or HasPunch(state, player)) and SuperFlyerOption
+def SuperFlyer(state, world):
+    return HasFlyer(state, world) and (
+            HasNet(state, world) or HasClub(state, world) or HasSling(state, world)
+            or HasPunch(state, world)) and world.options.superflyer == "true"
 
 
-def TJ_UFOEntry(state, player):
-    return CanDive(state, player)
+def TJ_UFOEntry(state, world):
+    return CanDive(state, world)
 
 
-def TJ_UFOCliff(state, player):
+def TJ_UFOCliff(state, world):
     return True
 
 
-def TJ_FishEntry(state, player):
-    return CanSwim(state, player) or HasFlyer(state, player)
+def TJ_FishEntry(state, world):
+    return CanSwim(state, world) or HasFlyer(state, world)
 
 
-def TJ_Mushroom(state, player):
-    return (HasMobility(state, player) and CanHitMultiple(state, player)) or SuperFlyer(state, player)
+def TJ_Mushroom(state, world):
+    return (HasMobility(state, world) and CanHitMultiple(state, world)) or SuperFlyer(state, world)
 
 
-def CR_Inside(state, player):
-    return HasSling(state, player) or HasPunch(state, player)
+def CR_Inside(state, world):
+    return HasSling(state, world) or HasPunch(state, world)
 
 
-def DI_SecondHalf(state, player):
-    return CanHitMultiple(state, player) and CanDive(state, player)
+def DI_SecondHalf(state, world):
+    return CanHitMultiple(state, world) and CanDive(state, world)
 
 
-def DI_Boulders(state, player):
-    return HasHoop(state, player) or HasFlyer(state, player) or HasRC(state, player)
+def DI_Boulders(state, world):
+    return HasHoop(state, world) or HasFlyer(state, world) or HasRC(state, world)
 
 
-def WSW_ThirdRoom(state, player):
-    return HasSling(state, player) or HasHoop(state, player) or HasFlyer(state, player)
+def WSW_ThirdRoom(state, world):
+    return HasSling(state, world) or HasHoop(state, world) or HasFlyer(state, world)
 
 
-def WSW_FourthRoom(state, player):
+def WSW_FourthRoom(state, world):
     return True
 
 
-def CC_5Monkeys(state, player):
-    return HasClub(state, player) or HasSling(state, player) or HasHoop(state, player) or HasFlyer(state,
-                                                                                                   player) or HasPunch(
-        state, player)
+def CC_5Monkeys(state, world):
+    return (HasClub(state, world) or HasSling(state, world) or HasHoop(state, world)
+            or HasFlyer(state, world) or HasPunch(state, world))
 
 
-def CC_WaterRoom(state, player):
-    return (CanHitMultiple(state, player) and HasNet(state, player)) or (CanDive(state, player) and (HasFlyer(state, player) or HasPunch(state, player))) or (HasFlyer(state, player) or HasHoop(state, player)) or SuperFlyer(state, player)
-
-def CC_ButtonRoom(state, player):
-    return CC_WaterRoom(state, player) and (CanSwim(state, player) or HasFlyer(state, player))
-
-
-def CP_FrontSewer(state, player):
-    return HasRC(state, player)
+def CC_WaterRoom(state, world):
+    return ((CanHitMultiple(state, world) and HasNet(state, world))
+            or (CanDive(state, world) and (HasFlyer(state, world) or HasPunch(state, world)))
+            or (HasFlyer(state, world) or HasHoop(state, world)) or SuperFlyer(state, world))
 
 
-def CP_FrontBarrels(state, player):
-    return CP_FrontSewer(state, player) and (CanSwim(state, player) or HasMobility(state, player))
+def CC_ButtonRoom(state, world):
+    return CC_WaterRoom(state, world) and (CanSwim(state, world) or HasFlyer(state, world))
 
 
-def CP_BackSewer(state, player):
-    return HasFlyer(state, player) and CanDive(state, player)
+def CP_FrontSewer(state, world):
+    return HasRC(state, world)
 
 
-def SF_CarRoom(state, player):
-    return (HasHoop(state, player) and HasFlyer(state, player)) or HasRC(state, player) or HasPunch(state, player)
+def CP_FrontBarrels(state, world):
+    return CP_FrontSewer(state, world) and (CanSwim(state, world) or HasMobility(state, world))
 
 
-def SF_MechRoom(state, player):
-    return (HasHoop(state, player) and HasFlyer(state, player)) or (
-            HasClub(state, player) and (HasSling(state, player) or HasRC(state, player))) or HasPunch(state, player) or SuperFlyer(state, player)
+def CP_BackSewer(state, world):
+    return HasFlyer(state, world) and CanDive(state, world)
 
 
-def TVT_HitButton(state, player):
-    return HasClub(state, player) or HasSling(state, player) or HasFlyer(state, player)
+def SF_CarRoom(state, world):
+    return (HasHoop(state, world) and HasFlyer(state, world)) or HasRC(state, world) or HasPunch(
+        state, world)
 
 
-def TVT_TankRoom(state, player):
-    return TVT_HitButton(state, player)
+def SF_MechRoom(state, world):
+    return ((HasHoop(state, world) and HasFlyer(state, world)) or (
+            HasClub(state, world) and (HasSling(state, world) or HasRC(state, world)))
+            or HasPunch(state, world) or SuperFlyer(state, world))
 
 
-def MM_Natalie(state, player):
-    return CanHitMultiple(state, player)
+def TVT_HitButton(state, world):
+    return HasClub(state, world) or HasSling(state, world) or HasFlyer(state, world)
 
 
-def MM_Professor(state, player):
-    return HasFlyer(state, player) and (HasClub(state, player) or HasSling(state, player) or HasPunch(state, player))
+def TVT_TankRoom(state, world):
+    return TVT_HitButton(state, world)
 
 
-def Jake_Open(state, player):
-    return MM_Natalie(state, player) and MM_Professor(state, player)
+def MM_Natalie(state, world):
+    return CanHitMultiple(state, world)
 
 
-def MM_Jake(state, player):
-    return CanHitMultiple(state, player) and Jake_Open(state, player)
+def MM_Professor(state, world):
+    return HasFlyer(state, world) and (
+            HasClub(state, world) or HasSling(state, world) or HasPunch(state, world))
 
 
-def MM_SHA(state, player):
-    return MM_Natalie(state, player) and MM_Professor(state, player) and MM_Jake(state, player)
+def Jake_Open(state, world):
+    return MM_Natalie(state, world) and MM_Professor(state, world)
 
 
-def MM_UFODoor(state, player):
-    return MM_SHA(state, player) and (HasClub(state, player) or HasSling(state, player) or HasPunch(state, player))
+def MM_Jake(state, world):
+    return CanHitMultiple(state, world) and Jake_Open(state, world)
 
 
-def MM_DoubleDoor(state, player):
-    return MM_UFODoor(state, player) and HasHoop(state, player) and HasRC(state, player)
+def MM_SHA(state, world):
+    return MM_Natalie(state, world) and MM_Professor(state, world) and MM_Jake(state, world)
 
 
-def MM_SpaceMonkeys(state, player):
-    return MM_DoubleDoor(state, player) and HasFlyer(state, player)
+def MM_UFODoor(state, world):
+    return MM_SHA(state, world) and (
+            HasClub(state, world) or HasSling(state, world) or HasPunch(state, world))
 
 
-def MM_FinalBoss(state, player):
-    return (MM_DoubleDoor(state, player) and HasSling(state, player) and HasFlyer(state, player)) or (MM_UFODoor(state, player) and SuperFlyer(state, player))
+def MM_DoubleDoor(state, world):
+    return MM_UFODoor(state, world) and HasHoop(state, world) and HasRC(state, world)
 
 
-def HasClub(state, player):
-    return state.has(AEItem.Club.value, player, 1)
+def MM_SpaceMonkeys(state, world):
+    return MM_DoubleDoor(state, world) and HasFlyer(state, world)
 
 
-def HasNet(state, player):
-    return state.has(AEItem.Net.value, player, 1)
+def MM_FinalBoss(state, world):
+    return ((MM_DoubleDoor(state, world) and HasSling(state, world) and HasFlyer(state, world))
+            or (MM_UFODoor(state, world) and SuperFlyer(state, world)))
 
 
-def HasRadar(state, player):
-    return state.has(AEItem.Radar.value, player, 1)
+def HasClub(state, world):
+    return state.has(AEItem.Club.value, world.player, 1)
 
 
-def HasSling(state, player):
-    return state.has(AEItem.Sling.value, player, 1)
+def HasNet(state, world):
+    return state.has(AEItem.Net.value, world.player, 1)
 
 
-def HasHoop(state, player):
-    return state.has(AEItem.Hoop.value, player, 1)
+def HasRadar(state, world):
+    return state.has(AEItem.Radar.value, world.player, 1)
 
 
-def HasFlyer(state, player):
-    return state.has(AEItem.Flyer.value, player, 1)
+def HasSling(state, world):
+    return state.has(AEItem.Sling.value, world.player, 1)
 
 
-def HasRC(state, player):
-    return state.has(AEItem.Car.value, player, 1)
+def HasHoop(state, world):
+    return state.has(AEItem.Hoop.value, world.player, 1)
 
 
-def HasPunch(state, player):
-    return state.has(AEItem.Punch.value, player, 1)
+def HasFlyer(state, world):
+    return state.has(AEItem.Flyer.value, world.player, 1)
 
 
-def HasWaterNet(state, player):
-    return state.has(AEItem.WaterNet.value, player, 1)
+def HasRC(state, world):
+    return state.has(AEItem.Car.value, world.player, 1)
+
+
+def HasPunch(state, world):
+    return state.has(AEItem.Punch.value, world.player, 1)
+
+
+def HasWaterNet(state, world):
+    return state.has(AEItem.WaterNet.value, world.player, 1)

--- a/worlds/apeescape/__init__.py
+++ b/worlds/apeescape/__init__.py
@@ -1,19 +1,18 @@
 import math
 import os
 import json
-from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple
+from typing import ClassVar, List, Optional
 
-from BaseClasses import Item, ItemClassification, MultiWorld, Tutorial
+from BaseClasses import ItemClassification, MultiWorld, Tutorial
 from worlds.AutoWorld import WebWorld, World
-from .Items import item_table, ItemData, nothing_item_id, event_table, ApeEscapeItem
+from .Items import item_table, ApeEscapeItem
 from .Locations import location_table, base_location_id
 from .Regions import create_regions
 from .Rules import set_rules
 from .Client import ApeEscapeClient
 from .Strings import AEItem, AELocation
 from .RAMAddress import RAM
-from .Options import ApeEscapeOptions, DebugOption, GoalOption, LogicOption, CoinOption
-from Options import AssembleOptions
+from .Options import ApeEscapeOptions
 
 
 class ApeEscapeWeb(WebWorld):
@@ -45,16 +44,15 @@ class ApeEscapeWorld(World):
     item_name_to_id = item_table
 
     for key, value in item_name_to_id.items():
-        item_name_to_id[key] = value + 128000000
+        item_name_to_id[key] = value + base_location_id
 
     location_name_to_id = location_table
 
     for key, value in location_name_to_id.items():
-        location_name_to_id[key] = value + 128000000
+        location_name_to_id[key] = value + base_location_id
 
-    def __init__(self, world: MultiWorld, player: int):
-        super().__init__(world, player)
-        self.game = "Ape Escape"
+    def __init__(self, multiworld: MultiWorld, player: int):
+        super().__init__(multiworld, player)
         self.debug: Optional[int] = 0
         self.goal: Optional[int] = 0
         self.logic: Optional[int] = 0
@@ -62,35 +60,35 @@ class ApeEscapeWorld(World):
         self.gadget: Optional[int] = 0
 
     def generate_early(self) -> None:
-        self.debug = self.options.debug
-        self.goal = self.options.goal
-        self.logic = self.options.logic
-        self.coin = self.options.coin
-        self.gadget = self.options.gadget
+        self.debug = self.options.debug.value
+        self.goal = self.options.goal.value
+        self.logic = self.options.logic.value
+        self.coin = self.options.coin.value
+        self.gadget = self.options.gadget.value
 
     def create_regions(self):
-        create_regions(self.multiworld,self.options, self.player)
+        create_regions(self)
 
     def set_rules(self):
-        set_rules(self.multiworld, self.player)
+        set_rules(self)
 
-    def create_item(self, name: str) -> Item:
+    def create_item(self, name: str) -> ApeEscapeItem:
         item_id = item_table[name]
         classification = ItemClassification.progression
 
         item = ApeEscapeItem(name, classification, item_id, self.player)
         return item
 
-    def create_item_filler(self, name: str) -> Item:
+    def create_item_filler(self, name: str) -> ApeEscapeItem:
         item_id = item_table[name]
         classification = ItemClassification.filler
 
         item = ApeEscapeItem(name, classification, item_id, self.player)
         return item
 
-
     def create_items(self):
         numberoflocations = len(location_table)
+        itempool: List[ApeEscapeItem] = []
 
         club = self.create_item(AEItem.Club.value)
         radar = self.create_item(AEItem.Radar.value)
@@ -106,106 +104,109 @@ class ApeEscapeWorld(World):
 
         self.multiworld.push_precollected(waternet)
 
-        if self.multiworld.debug[self.player].value == 0x00:
-            self.multiworld.itempool += [self.create_item(AEItem.Key.value) for i in range(0, 6)]
+        if self.options.debug == "off":
+            itempool += [self.create_item(AEItem.Key.value) for _ in range(0, 6)]
             numberoflocations -= 6
         # DEBUG
-        elif self.multiworld.debug[self.player].value == 0x01:
+        elif self.options.debug == "item":
             self.multiworld.push_precollected(club)
-            self.multiworld.get_location(AELocation.Noonan.value, self.player).place_locked_item(radar)
-            self.multiworld.get_location(AELocation.Jorjy.value, self.player).place_locked_item(shooter)
-            self.multiworld.get_location(AELocation.Nati.value, self.player).place_locked_item(hoop)
-            self.multiworld.get_location(AELocation.Shay.value, self.player).place_locked_item(flyer)
-            self.multiworld.get_location(AELocation.DrMonk.value, self.player).place_locked_item(car)
-            self.multiworld.get_location(AELocation.Ahchoo.value, self.player).place_locked_item(punch)
-            self.multiworld.itempool += [self.create_item(AEItem.Key.value) for i in range(0, 6)]
+            self.get_location(AELocation.Noonan.value).place_locked_item(radar)
+            self.get_location(AELocation.Jorjy.value).place_locked_item(shooter)
+            self.get_location(AELocation.Nati.value).place_locked_item(hoop)
+            self.get_location(AELocation.Shay.value).place_locked_item(flyer)
+            self.get_location(AELocation.DrMonk.value).place_locked_item(car)
+            self.get_location(AELocation.Ahchoo.value).place_locked_item(punch)
+            itempool += [self.create_item(AEItem.Key.value) for _ in range(0, 6)]
             numberoflocations -= 12
         # DEBUG
-        elif self.multiworld.debug[self.player].value == 0x02:
+        elif self.options.debug == "key":
             self.multiworld.push_precollected(club)
-            self.multiworld.itempool += [radar, shooter, hoop, flyer, car, punch]
+            itempool += [
+                self.create_item(AEItem.Club.value),
+                self.create_item(AEItem.Sling.value),
+                self.create_item(AEItem.Hoop.value),
+                self.create_item(AEItem.Flyer.value),
+                self.create_item(AEItem.Car.value),
+                self.create_item(AEItem.Punch.value),
+            ]
             key1 = self.create_item("World Key")
             key2 = self.create_item("World Key")
             key3 = self.create_item("World Key")
             key4 = self.create_item("World Key")
             key5 = self.create_item("World Key")
             key6 = self.create_item("World Key")
-            self.multiworld.get_location(AELocation.Noonan.value, self.player).place_locked_item(key1)
-            self.multiworld.get_location(AELocation.Jorjy.value, self.player).place_locked_item(key2)
-            self.multiworld.get_location(AELocation.Nati.value, self.player).place_locked_item(key3)
-            self.multiworld.get_location(AELocation.Shay.value, self.player).place_locked_item(key4)
-            self.multiworld.get_location(AELocation.DrMonk.value, self.player).place_locked_item(key5)
-            self.multiworld.get_location(AELocation.Ahchoo.value, self.player).place_locked_item(key6)
+            self.get_location(AELocation.Noonan.value).place_locked_item(key1)
+            self.get_location(AELocation.Jorjy.value).place_locked_item(key2)
+            self.get_location(AELocation.Nati.value).place_locked_item(key3)
+            self.get_location(AELocation.Shay.value).place_locked_item(key4)
+            self.get_location(AELocation.DrMonk.value).place_locked_item(key5)
+            self.get_location(AELocation.Ahchoo.value).place_locked_item(key6)
             numberoflocations -= 12
 
-
-
-        if self.multiworld.gadget[self.player].value == 0x00:
+        if self.options.gadget == "club":
             self.multiworld.push_precollected(club)
-            self.multiworld.itempool += [radar, shooter, hoop, flyer, car, punch]
+            itempool += [radar, shooter, hoop, flyer, car, punch]
             numberoflocations -= 6
-        elif self.multiworld.gadget[self.player].value == 0x01:
+        elif self.options.gadget == "radar":
             self.multiworld.push_precollected(radar)
-            self.multiworld.itempool += [club, shooter, hoop, flyer, car, punch]
+            itempool += [club, shooter, hoop, flyer, car, punch]
             numberoflocations -= 6
-        elif self.multiworld.gadget[self.player].value == 0x02:
+        elif self.options.gadget == "sling":
             self.multiworld.push_precollected(shooter)
-            self.multiworld.itempool += [club, radar, hoop, flyer, car, punch]
+            itempool += [club, radar, hoop, flyer, car, punch]
             numberoflocations -= 6
-        elif self.multiworld.gadget[self.player].value == 0x03:
+        elif self.options.gadget == "hoop":
             self.multiworld.push_precollected(hoop)
-            self.multiworld.itempool += [club, radar, shooter, flyer, car, punch]
+            itempool += [club, radar, shooter, flyer, car, punch]
             numberoflocations -= 6
-        elif self.multiworld.gadget[self.player].value == 0x04:
+        elif self.options.gadget == "flyer":
             self.multiworld.push_precollected(flyer)
-            self.multiworld.itempool += [club, radar, shooter, hoop, car, punch]
+            itempool += [club, radar, shooter, hoop, car, punch]
             numberoflocations -= 6
-        elif self.multiworld.gadget[self.player].value == 0x05:
+        elif self.options.gadget == "car":
             self.multiworld.push_precollected(car)
-            self.multiworld.itempool += [club, radar, shooter, hoop, flyer, punch]
+            itempool += [club, radar, shooter, hoop, flyer, punch]
             numberoflocations -= 6
-        elif self.multiworld.gadget[self.player].value == 0x06:
+        elif self.options.gadget == "punch":
             self.multiworld.push_precollected(punch)
-            self.multiworld.itempool += [club, radar, shooter, hoop, flyer, car]
+            itempool += [club, radar, shooter, hoop, flyer, car]
             numberoflocations -= 6
-        elif self.multiworld.gadget[self.player].value == 0x08:
-            self.multiworld.itempool += [club, radar, shooter, hoop, flyer, car, punch]
+        elif self.options.gadget == "none":
+            itempool += [club, radar, shooter, hoop, flyer, car, punch]
             numberoflocations -= 7
 
-
-
-        if self.options.coin.value == 0x01:
+        if self.options.coin == "false":
             numberoflocations -= 60
 
-
-
-        if self.options.goal.value == 0x00:
-            self.multiworld.get_location(AELocation.Specter.value, self.player).place_locked_item(victory)
+        if self.options.goal == "first":
+            self.get_location(AELocation.Specter.value).place_locked_item(victory)
             numberoflocations -= 1
         else:
-            self.multiworld.get_location(AELocation.Specter2.value, self.player).place_locked_item(victory)
+            self.get_location(AELocation.Specter2.value).place_locked_item(victory)
 
         sixth = math.floor(numberoflocations/6)
 
-        self.multiworld.itempool += [self.create_item_filler(AEItem.Shirt.value) for i in range(0, sixth)]
+        itempool += [self.create_item_filler(AEItem.Shirt.value) for _ in range(0, sixth)]
         numberoflocations -= sixth
 
-        self.multiworld.itempool += [self.create_item_filler(AEItem.Triangle.value) for i in range(0, sixth)]
+        itempool += [self.create_item_filler(AEItem.Triangle.value) for _ in range(0, sixth)]
         numberoflocations -= sixth
 
-        self.multiworld.itempool += [self.create_item_filler(AEItem.BigTriangle.value) for i in range(0, sixth)]
+        itempool += [self.create_item_filler(AEItem.BigTriangle.value) for _ in range(0, sixth)]
         numberoflocations -= sixth
 
-        self.multiworld.itempool += [self.create_item_filler(AEItem.Cookie.value) for i in range(0, sixth)]
+        itempool += [self.create_item_filler(AEItem.Cookie.value) for _ in range(0, sixth)]
         numberoflocations -= sixth
 
-        self.multiworld.itempool += [self.create_item_filler(AEItem.Flash.value) for i in range(0, sixth)]
+        itempool += [self.create_item_filler(AEItem.Flash.value) for _ in range(0, sixth)]
         numberoflocations -= sixth
 
-        self.multiworld.itempool += [self.create_item_filler(AEItem.Rocket.value) for i in range(0, sixth)]
+        itempool += [self.create_item_filler(AEItem.Rocket.value) for _ in range(0, sixth)]
         numberoflocations -= sixth
 
-        self.multiworld.itempool += [self.create_item_filler(AEItem.Nothing.value) for i in range(0, numberoflocations)]
+        itempool += [self.create_item_filler(AEItem.Nothing.value) for _ in range(0, numberoflocations)]
+
+        self.multiworld.itempool += itempool
 
     def fill_slot_data(self):
         return {
@@ -222,7 +223,7 @@ class ApeEscapeWorld(World):
         data = {
             "slot_data": self.fill_slot_data(),
             "location_to_item": {self.location_name_to_id[i.name]: item_table[i.item.name] for i in
-                                 self.multiworld.get_locations()},
+                                 self.multiworld.get_filled_locations()},
             "data_package": {
                 "data": {
                     "games": {

--- a/worlds/apeescape/__init__.py
+++ b/worlds/apeescape/__init__.py
@@ -223,7 +223,7 @@ class ApeEscapeWorld(World):
         data = {
             "slot_data": self.fill_slot_data(),
             "location_to_item": {self.location_name_to_id[i.name]: item_table[i.item.name] for i in
-                                 self.multiworld.get_filled_locations()},
+                                 self.multiworld.get_locations()},
             "data_package": {
                 "data": {
                     "games": {


### PR DESCRIPTION
## What is this fixing or adding?

The primary thing this is changing in the signatures of  `create_regions`, `set_rules`, and `connect_regions` to just use the `world` object instead of multiworld and other things like `player`.

This also removes some unused code/classes, unused imports, fixes some spacing, changes instances where the `multiworld` object was being called `world` to now call it `multiworld`, converts set_rules to just call functions instead of needing its own class, fixes some times where an option class was being used instead of the value, changes the itempool to use ApeEscapeItems instead of just regular Items and also uses a local itempool that adds to the mulitworld itempool at the very end to save some time and in case it gets used later, changes options comparisons with numbers to instead use strings, uses the helper functions such as `world.get_location` instead of `multiworld.get_location`, converts some old option-checking methods to use the new options system, and uses the `_` dummy variable for loops.

This also fixes a bug in `__init__` where multiple items could be added to the pool that references the same object, for example, multiple items referencing the same `sling` object could be added (one from the `gadget` option and the other from having the `debug` option set to `key`.

## How was this tested?

Exclusively through unit tests and lots of generations with comparing the results before and after the changes and looking through spoiler logs. It should get more thorough testing.